### PR TITLE
Adding logic to specify NLPModel options

### DIFF
--- a/lib/coek/coek/autograd/asl_repn.cpp
+++ b/lib/coek/coek/autograd/asl_repn.cpp
@@ -37,6 +37,8 @@ ASL_Repn::ASL_Repn(Model& model) : NLPModelRepn(model)
     // First assume that we don't want to halt on error (default)
     nerror_ = (void*)new fint;
     *(fint*)nerror_ = 0;
+
+    temp_directory = "/tmp/";
 }
 
 ASL_Repn::~ASL_Repn()
@@ -208,7 +210,7 @@ void ASL_Repn::compute_J(std::vector<double>& J)
     nerror_ok = check_asl_status(nerror_);
 }
 
-void ASL_Repn::initialize(bool /*_sparse_JH*/)
+void ASL_Repn::initialize()
 {
     //
     // Initialize the NLPModelRepn data
@@ -296,7 +298,7 @@ void ASL_Repn::alloc_asl()
     //
     // Create a temporary filename
     //
-    std::string fname = "/tmp/coek_XXXXXX";
+    std::string fname = temp_directory + "coek_XXXXXX";
     std::string tmp = mktemp(&fname[0]);
     if (tmp.size() == 0)
         throw std::runtime_error("Failure to create temporary file for ASL interface");
@@ -407,6 +409,21 @@ void ASL_Repn::call_hesset()
     int mult_supplied = 1;  // multipliers will be supplied
     int uptri = 1;          // only need the upper triangular part
     nnz_lag_h = static_cast<size_t>(sphsetup(-1, coeff_obj, mult_supplied, uptri));
+}
+
+bool ASL_Repn::get_option(const std::string& option, std::string& value) const
+{
+if (option == "temp_directory") {
+    value = temp_directory;
+    return true;
+    }
+return false;
+}
+
+void ASL_Repn::set_option(const std::string& option, const std::string value)
+{
+if (option == "temp_directory")
+    temp_directory = value;
 }
 
 }  // namespace coek

--- a/lib/coek/coek/autograd/asl_repn.hpp
+++ b/lib/coek/coek/autograd/asl_repn.hpp
@@ -20,6 +20,8 @@ class ASL_Repn : public NLPModelRepn {
    public:
     // The main ASL structure
     ASL_pfgh* asl_;
+    // The temporary file directory used to write the NL file
+    std::string temp_directory;
 
     // ----------------------------------------------------------------------
     // Problem information
@@ -56,7 +58,7 @@ class ASL_Repn : public NLPModelRepn {
     ASL_Repn(Model& model);
     ~ASL_Repn();
 
-    void initialize(bool sparse_JH = true);
+    void initialize();
 
     void reset(void);
 
@@ -92,6 +94,10 @@ class ASL_Repn : public NLPModelRepn {
     void compute_H(std::vector<double>& w, std::vector<double>& H);
 
     void compute_J(std::vector<double>& J);
+
+   public:
+    bool get_option(const std::string& option, std::string& value) const;
+    void set_option(const std::string& option, const std::string value);
 
    protected:
     void* nerror_;

--- a/lib/coek/coek/autograd/autograd.hpp
+++ b/lib/coek/coek/autograd/autograd.hpp
@@ -22,7 +22,7 @@ class NLPModelRepn {
     NLPModelRepn(Model& _model) : model(_model) {}
     virtual ~NLPModelRepn() {}
 
-    virtual void initialize(bool sparse_JH = true) = 0;
+    virtual void initialize() = 0;
     virtual void reset(void) = 0;
 
     virtual size_t num_variables() const = 0;
@@ -57,6 +57,62 @@ class NLPModelRepn {
 
    public:
     void find_used_variables();
+
+    public:
+
+    /** Get the value of an integer option
+     *
+     * The option value is returned by reference if it has
+     * a value.
+     *
+     * \param option  the option name
+     * \param value   an integer value that is passed by reference
+     *
+     * \returns \c true if the option is found
+     */
+    virtual bool get_option(const std::string& /*option*/, int& /*value*/) const {return false;}
+    /** Get the value of a double option
+     *
+     * The option value is returned by reference if it has
+     * a value.
+     *
+     * \param option  the option name
+     * \param value   a double value that is passed by reference
+     *
+     * \returns \c true if the option is found
+     */
+    virtual bool get_option(const std::string& /*option*/, double& /*value*/) const {return false;}
+    /** Get the value of a string option
+     *
+     * The option value is returned by reference if it has
+     * a value.
+     *
+     * \param option  the option name
+     * \param value   a string value that is passed by reference
+     *
+     * \returns \c true if the option is found
+     */
+    virtual bool get_option(const std::string& /*option*/, std::string& /*value*/) const { return false; }
+
+    /** Set an integer option
+     *
+     * \param option  the option name
+     * \param value   the integer value
+     */
+    virtual void set_option(const std::string& /*option*/, int /*value*/) {}
+    /** Set a double option
+     *
+     * \param option  the option name
+     * \param value   the double value
+     */
+    virtual void set_option(const std::string& /*option*/, double /*value*/) { }
+    /** Set a string option
+     *
+     * \param option  the option name
+     * \param value   the string value
+     */
+    virtual void set_option(const std::string& /*option*/, const std::string /*value*/) { }
+
 };
 
 NLPModelRepn* create_NLPModelRepn(Model& model, const std::string& name);

--- a/lib/coek/coek/autograd/cppad_repn.cpp
+++ b/lib/coek/coek/autograd/cppad_repn.cpp
@@ -291,9 +291,8 @@ void CppAD_Repn::create_CppAD_function()
     ADfc.optimize();
 }
 
-void CppAD_Repn::initialize(bool _sparse_JH)
+void CppAD_Repn::initialize()
 {
-    sparse_JH = _sparse_JH;
     //
     // Find all variables used in the NLP model
     //
@@ -589,6 +588,22 @@ void CppAD_Repn::reset(void)
     }
     set_variables(currx);
 }
+
+bool CppAD_Repn::get_option(const std::string& option, int& value) const
+{
+if (option == "sparse_JH") {
+    value = sparse_JH;
+    return true;
+    }
+return false;
+}
+
+void CppAD_Repn::set_option(const std::string& option, int value)
+{
+if (option == "sparse_JH")
+    sparse_JH = (value==1);
+}
+
 
 //
 // This empty namespace contains functions used to walk the COEK

--- a/lib/coek/coek/autograd/cppad_repn.hpp
+++ b/lib/coek/coek/autograd/cppad_repn.hpp
@@ -89,7 +89,7 @@ class CppAD_Repn : public NLPModelRepn {
    public:
     CppAD_Repn(Model& model);
 
-    void initialize(bool sparse_JH = true);
+    void initialize();
 
     void reset(void);
 
@@ -125,6 +125,12 @@ class CppAD_Repn : public NLPModelRepn {
     void compute_H(std::vector<double>& w, std::vector<double>& H);
 
     void compute_J(std::vector<double>& J);
+
+   public:
+
+    bool get_option(const std::string& option, int& value) const;
+
+    void set_option(const std::string& option, int value);
 
    public:
     void create_CppAD_function();

--- a/lib/coek/coek/autograd/unknownad_repn.hpp
+++ b/lib/coek/coek/autograd/unknownad_repn.hpp
@@ -16,7 +16,7 @@ class UnknownAD_Repn : public NLPModelRepn {
    public:
     UnknownAD_Repn(const std::string& ad_type_) : ad_type(ad_type_) {}
 
-    void initialize(bool /*sparse_JH*/ = true) {}  // GCOVR_EXCL_LINE
+    void initialize() {}  // GCOVR_EXCL_LINE
 
     void reset(void) {}
 

--- a/lib/coek/coek/model/nlp_model.cpp
+++ b/lib/coek/coek/model/nlp_model.cpp
@@ -8,6 +8,58 @@
 namespace coek {
 
 //
+// OptionCache
+//
+
+class OptionCacheRepn {
+public:
+    std::map<std::string, std::string> string_options;
+    std::map<std::string, int> integer_options;
+    std::map<std::string, double> double_options;
+};
+
+OptionCache::OptionCache()
+{
+    options = std::make_shared<OptionCacheRepn>();
+}
+
+bool OptionCache::get_option(const std::string& option, int& value) const
+{
+auto it = options->integer_options.find(option);
+if (it == options->integer_options.end())
+    return false;
+value = it->second;
+return true;
+}
+
+bool OptionCache::get_option(const std::string& option, double& value) const
+{
+auto it = options->double_options.find(option);
+if (it == options->double_options.end())
+    return false;
+value = it->second;
+return true;
+}
+
+bool OptionCache::get_option(const std::string& option, std::string& value) const
+{
+auto it = options->string_options.find(option);
+if (it == options->string_options.end())
+    return false;
+value = it->second;
+return true;
+}
+
+void OptionCache::set_option(const std::string& option, int value)
+{ options->integer_options[option] = value; }
+
+void OptionCache::set_option(const std::string& option, double value)
+{ options->double_options[option] = value; }
+
+void OptionCache::set_option(const std::string& option, const std::string value)
+{ options->string_options[option] = value; }
+
+//
 // NLPModel
 //
 
@@ -17,16 +69,24 @@ NLPModel::NLPModel()
     repn = tmp;
 }
 
-NLPModel::NLPModel(Model& model, std::string type, bool sparse_JH)
+NLPModel::NLPModel(Model& model, std::string type)
 {
-    initialize(model, type, sparse_JH);
+    initialize(model, type);
 }
 
-void NLPModel::initialize(Model& model, std::string type, bool sparse_JH)
+void NLPModel::initialize(Model& model, std::string type)
 {
     std::shared_ptr<NLPModelRepn> tmp(create_NLPModelRepn(model, type));
     repn = tmp;
-    repn->initialize(sparse_JH);
+
+    for (const auto& ioption: options->integer_options)
+        repn->set_option(ioption.first, ioption.second);
+    for (const auto& doption: options->double_options)
+        repn->set_option(doption.first, doption.second);
+    for (const auto& soption: options->string_options)
+        repn->set_option(soption.first, soption.second);
+
+    repn->initialize();
 }
 
 void NLPModel::reset() { repn->reset(); }

--- a/lib/coek/coek/model/nlp_model.hpp
+++ b/lib/coek/coek/model/nlp_model.hpp
@@ -5,12 +5,76 @@
 namespace coek {
 
 class NLPModelRepn;
+class OptionCacheRepn;
+
+class OptionCache {
+   public:
+    std::shared_ptr<OptionCacheRepn> options;
+
+    public:
+
+    OptionCache();
+
+    /** Get the value of an integer option
+     *
+     * The option value is returned by reference if it has
+     * a value.
+     *
+     * \param option  the option name
+     * \param value   an integer value that is passed by reference
+     *
+     * \returns \c true if the option is found
+     */
+    bool get_option(const std::string& option, int& value) const;
+    /** Get the value of a double option
+     *
+     * The option value is returned by reference if it has
+     * a value.
+     *
+     * \param option  the option name
+     * \param value   a double value that is passed by reference
+     *
+     * \returns \c true if the option is found
+     */
+    bool get_option(const std::string& option, double& value) const;
+    /** Get the value of a string option
+     *
+     * The option value is returned by reference if it has
+     * a value.
+     *
+     * \param option  the option name
+     * \param value   a string value that is passed by reference
+     *
+     * \returns \c true if the option is found
+     */
+    bool get_option(const std::string& option, std::string& value) const;
+
+    /** Set an integer option
+     *
+     * \param option  the option name
+     * \param value   the integer value
+     */
+    void set_option(const std::string& option, int value);
+    /** Set a double option
+     *
+     * \param option  the option name
+     * \param value   the double value
+     */
+    void set_option(const std::string& option, double value);
+    /** Set a string option
+     *
+     * \param option  the option name
+     * \param value   the string value
+     */
+    void set_option(const std::string& option, const std::string value);
+};
+
 
 /**
  * An optimization model that provides a view of a coek::Model
  * object that support computations needed for NLP solvers.
  */
-class NLPModel {
+class NLPModel : public OptionCache {
    public:
     std::shared_ptr<NLPModelRepn> repn;
 
@@ -21,19 +85,15 @@ class NLPModel {
      *
      * \param model  a coek::Model
      * \param type  the type of AD used for computations
-     * \param sparse_JH  a boolean that indicates if sparse Jacobian and Hessian computations are
-     * used (default is \c true)
      */
-    NLPModel(Model& model, std::string type, bool sparse_JH = true);
+    NLPModel(Model& model, std::string type);
 
     /** Initialize the NLP model view
      *
      * \param model  a coek::Model
      * \param type  the type of AD used for computations
-     * \param sparse_JH  a boolean that indicates if sparse Jacobian and Hessian computations are
-     * used (default is \c true)
      */
-    void initialize(Model& model, std::string type, bool sparse_JH = true);
+    void initialize(Model& model, std::string type);
 
     /** TODO - maybe this should be called 'update' */
     void reset();

--- a/lib/coek/test/test_autograd_asl.cpp
+++ b/lib/coek/test/test_autograd_asl.cpp
@@ -42,6 +42,26 @@ TEST_CASE("asl_add", "[smoke]")
         REQUIRE_THROWS_WITH(nlp.initialize(model, "bad"), "Unexpected NLP model type: bad");
     }
 
+    SECTION("options")
+    {
+        coek::Model model;
+        auto x = model.add_variable("x").lower(0).upper(1).value(0);
+        auto y = model.add_variable("y").lower(0).upper(1).value(0);
+        model.add_objective("o", x + y);
+        coek::NLPModel m;
+
+        std::string dir;
+        REQUIRE(m.get_option("bad_option", dir) == false);
+        REQUIRE(m.get_option("temp_directory", dir) == false);
+
+        m.set_option("temp_directory", "foo");
+        REQUIRE(m.get_option("temp_directory", dir) == true);
+        REQUIRE(dir == "foo");
+
+        m.set_option("temp_directory", "./");
+        m.initialize(model, ADNAME);
+    }
+
     SECTION("Variables")
     {
         coek::Model model;

--- a/lib/coek/test/test_autograd_cppad.cpp
+++ b/lib/coek/test/test_autograd_cppad.cpp
@@ -315,7 +315,9 @@ TEST_CASE("cppad_ad", "[smoke]")
             model.add_constraint(a * b <= 0);
             model.add_constraint(b <= 0);
 
-            coek::NLPModel nlp(model, ADNAME, false);
+            coek::NLPModel nlp;
+            nlp.set_option("sparse_JH", false);
+            nlp.initialize(model, ADNAME);
             REQUIRE(nlp.num_nonzeros_Jacobian() == 6);
 
             std::vector<double> x{0, 1};
@@ -340,7 +342,9 @@ TEST_CASE("cppad_ad", "[smoke]")
             model.add_constraint(a + a * b + b <= 0);
             model.add_constraint(b + b * c + c <= 0);
 
-            coek::NLPModel nlp(model, ADNAME, false);
+            coek::NLPModel nlp;
+            nlp.set_option("sparse_JH", false);
+            nlp.initialize(model, ADNAME);
             REQUIRE(nlp.num_nonzeros_Jacobian() == 6);
 
             std::vector<double> x{0, 1, 2};
@@ -483,7 +487,9 @@ TEST_CASE("cppad_ad", "[smoke]")
             model.add_constraint(a * b <= 0);
             model.add_constraint(b <= 0);
 
-            coek::NLPModel nlp(model, ADNAME, false);
+            coek::NLPModel nlp;
+            nlp.set_option("sparse_JH", false);
+            nlp.initialize(model, ADNAME);
             REQUIRE(nlp.num_nonzeros_Hessian_Lagrangian() == 3);
 
             // H = [ [ 2, 1 ]
@@ -509,7 +515,9 @@ TEST_CASE("cppad_ad", "[smoke]")
             model.add_constraint(a + a * b + b <= 0);
             model.add_constraint(b + b * c + c <= 0);
 
-            coek::NLPModel nlp(model, ADNAME, false);
+            coek::NLPModel nlp;
+            nlp.set_option("sparse_JH", false);
+            nlp.initialize(model, ADNAME);
             REQUIRE(nlp.num_nonzeros_Hessian_Lagrangian() == 10);
 
             // H = [ [ 0, 1, 0, 0 ]


### PR DESCRIPTION
This was motivated by the need to specify a "temp_directory" option for the ASL interface, but it also simplifies and standardizes the interface for sparse/dense logic in the CppAD interface