### PR TITLE
Ipopt bounds fix

### DIFF
--- a/lib/coek/coek/ast/constraint_terms.cpp
+++ b/lib/coek/coek/ast/constraint_terms.cpp
@@ -12,15 +12,14 @@ namespace {
 std::mutex ObjectiveTerm_mtx;
 std::mutex ConstraintTerm_mtx;
 
-}
-
+}  // namespace
 
 //
 // ObjectiveTerm
 //
 unsigned int ObjectiveTerm::count = 0;
 
-ObjectiveTerm::ObjectiveTerm() : body(ZeroConstant), sense(true) 
+ObjectiveTerm::ObjectiveTerm() : body(ZeroConstant), sense(true)
 {
     ObjectiveTerm_mtx.lock();
     index = count++;
@@ -40,8 +39,8 @@ ObjectiveTerm::ObjectiveTerm(const expr_pointer_t& _body, bool _sense) : body(_b
 
 unsigned int ConstraintTerm::count = 0;
 
-ConstraintTerm::ConstraintTerm() 
-{ 
+ConstraintTerm::ConstraintTerm()
+{
     ConstraintTerm_mtx.lock();
     index = count++;
     ConstraintTerm_mtx.unlock();

--- a/lib/coek/coek/ast/expr_terms.cpp
+++ b/lib/coek/coek/ast/expr_terms.cpp
@@ -2,7 +2,6 @@
 #include <cassert>
 #include "expr_terms.hpp"
 
-
 namespace coek {
 
 namespace {
@@ -12,7 +11,7 @@ namespace {
 //
 std::mutex SubExpressionTerm_mtx;
 
-}
+}  // namespace
 
 //
 // SubExpressionTerm
@@ -20,7 +19,7 @@ std::mutex SubExpressionTerm_mtx;
 
 unsigned int SubExpressionTerm::count = 0;
 
-SubExpressionTerm::SubExpressionTerm(const expr_pointer_t& body) : UnaryTerm(body) 
+SubExpressionTerm::SubExpressionTerm(const expr_pointer_t& body) : UnaryTerm(body)
 {
     SubExpressionTerm_mtx.lock();
     index = count++;
@@ -30,7 +29,6 @@ SubExpressionTerm::SubExpressionTerm(const expr_pointer_t& body) : UnaryTerm(bod
 //
 // UnaryTerm
 //
-
 
 BinaryTerm::BinaryTerm(const expr_pointer_t& _lhs, const expr_pointer_t& _rhs)
     : lhs(_lhs), rhs(_rhs)

--- a/lib/coek/coek/ast/expr_terms.hpp
+++ b/lib/coek/coek/ast/expr_terms.hpp
@@ -176,26 +176,15 @@ class DivideTerm : public BinaryTerm {
 // Unary Terms
 //
 
-#define UNARY_CLASS(FN, TERM)                                       \
-    class TERM : public UnaryTerm {                                 \
-       public:                                                      \
-        explicit TERM(const expr_pointer_t& body) : UnaryTerm(body) \
-        {                                                           \
-        }                                                           \
-                                                                    \
-        double _eval() const                                        \
-        {                                                           \
-            return ::FN(body->_eval());                             \
-        }                                                           \
-                                                                    \
-        void accept(Visitor& v)                                     \
-        {                                                           \
-            v.visit(*this);                                         \
-        }                                                           \
-        term_id id()                                                \
-        {                                                           \
-            return TERM##_id;                                       \
-        }                                                           \
+#define UNARY_CLASS(FN, TERM)                                          \
+    class TERM : public UnaryTerm {                                    \
+       public:                                                         \
+        explicit TERM(const expr_pointer_t& body) : UnaryTerm(body) {} \
+                                                                       \
+        double _eval() const { return ::FN(body->_eval()); }           \
+                                                                       \
+        void accept(Visitor& v) { v.visit(*this); }                    \
+        term_id id() { return TERM##_id; }                             \
     };
 
 UNARY_CLASS(fabs, AbsTerm)
@@ -235,26 +224,15 @@ UNARY_CLASS(atanh, ATanhTerm)
 // Binary Terms
 //
 
-#define BINARY_CLASS(FN, TERM)                                                            \
-    class TERM : public BinaryTerm {                                                      \
-       public:                                                                            \
-        TERM(const expr_pointer_t& lhs, const expr_pointer_t& rhs) : BinaryTerm(lhs, rhs) \
-        {                                                                                 \
-        }                                                                                 \
-                                                                                          \
-        double _eval() const                                                              \
-        {                                                                                 \
-            return ::FN(lhs->_eval(), rhs->_eval());                                      \
-        }                                                                                 \
-                                                                                          \
-        void accept(Visitor& v)                                                           \
-        {                                                                                 \
-            v.visit(*this);                                                               \
-        }                                                                                 \
-        term_id id()                                                                      \
-        {                                                                                 \
-            return TERM##_id;                                                             \
-        }                                                                                 \
+#define BINARY_CLASS(FN, TERM)                                                               \
+    class TERM : public BinaryTerm {                                                         \
+       public:                                                                               \
+        TERM(const expr_pointer_t& lhs, const expr_pointer_t& rhs) : BinaryTerm(lhs, rhs) {} \
+                                                                                             \
+        double _eval() const { return ::FN(lhs->_eval(), rhs->_eval()); }                    \
+                                                                                             \
+        void accept(Visitor& v) { v.visit(*this); }                                          \
+        term_id id() { return TERM##_id; }                                                   \
     };
 
 BINARY_CLASS(pow, PowTerm)

--- a/lib/coek/coek/ast/value_terms.cpp
+++ b/lib/coek/coek/ast/value_terms.cpp
@@ -14,8 +14,7 @@ namespace {
 std::mutex ParameterTerm_mtx;
 std::mutex VariableTerm_mtx;
 
-}
-
+}  // namespace
 
 //
 // BaseExpressionTerm

--- a/lib/coek/coek/autograd/asl_repn.cpp
+++ b/lib/coek/coek/autograd/asl_repn.cpp
@@ -71,21 +71,28 @@ void ASL_Repn::set_variables(const double* x, size_t n)
 }
 
 bool ASL_Repn::has_constraint_lower(size_t i)
-{    ASL_pfgh* asl = asl_;
-return LUrhs[i] > negInfinity; }
+{
+    ASL_pfgh* asl = asl_;
+    return LUrhs[i] > negInfinity;
+}
 
 bool ASL_Repn::has_constraint_upper(size_t i)
-{    ASL_pfgh* asl = asl_;
-return Urhsx[i] < Infinity; }
+{
+    ASL_pfgh* asl = asl_;
+    return Urhsx[i] < Infinity;
+}
 
 double ASL_Repn::get_constraint_lower(size_t i)
-{    ASL_pfgh* asl = asl_;
-return LUrhs[i]; }
+{
+    ASL_pfgh* asl = asl_;
+    return LUrhs[i];
+}
 
 double ASL_Repn::get_constraint_upper(size_t i)
-{    ASL_pfgh* asl = asl_;
-return Urhsx[i]; }
-
+{
+    ASL_pfgh* asl = asl_;
+    return Urhsx[i];
+}
 
 void ASL_Repn::get_J_nonzeros(std::vector<size_t>& jrow, std::vector<size_t>& jcol)
 {
@@ -345,8 +352,8 @@ void ASL_Repn::alloc_asl()
     // allocate space for data read in by pfgh_read()
     //
     X0 = new real[n_var];
-    LUv = new real[2*n_var];
-    //Uvx = new real[n_var];
+    LUv = new real[2 * n_var];
+    // Uvx = new real[n_var];
     LUrhs = new real[n_var];
     Urhsx = new real[n_var];
     havex0 = new char[n_var];
@@ -357,8 +364,7 @@ void ASL_Repn::alloc_asl()
     //
     // Close and remove the file
     //
-    if (remove_nl_file)
-        remove(fname.c_str());
+    if (remove_nl_file) remove(fname.c_str());
 
     //
     // No errors, so return
@@ -454,32 +460,30 @@ void ASL_Repn::call_hesset()
 
 bool ASL_Repn::get_option(const std::string& option, std::string& value) const
 {
-if (option == "temp_directory") {
-    value = temp_directory;
-    return true;
+    if (option == "temp_directory") {
+        value = temp_directory;
+        return true;
     }
-return false;
+    return false;
 }
 
 bool ASL_Repn::get_option(const std::string& option, int& value) const
 {
-if (option == "remove_nl_file") {
-    value = remove_nl_file;
-    return true;
+    if (option == "remove_nl_file") {
+        value = remove_nl_file;
+        return true;
     }
-return false;
+    return false;
 }
 
 void ASL_Repn::set_option(const std::string& option, const std::string value)
 {
-if (option == "temp_directory")
-    temp_directory = value;
+    if (option == "temp_directory") temp_directory = value;
 }
 
 void ASL_Repn::set_option(const std::string& option, int value)
 {
-if (option == "remove_nl_file")
-    remove_nl_file = value;
+    if (option == "remove_nl_file") remove_nl_file = value;
 }
 
 }  // namespace coek

--- a/lib/coek/coek/autograd/asl_repn.cpp
+++ b/lib/coek/coek/autograd/asl_repn.cpp
@@ -38,7 +38,7 @@ ASL_Repn::ASL_Repn(Model& model) : NLPModelRepn(model)
     nerror_ = (void*)new fint;
     *(fint*)nerror_ = 0;
 
-    temp_directory = "/tmp/";
+    temp_directory = "/tmp";
 }
 
 ASL_Repn::~ASL_Repn()
@@ -69,6 +69,23 @@ void ASL_Repn::set_variables(const double* x, size_t n)
     objval_called_with_current_x_ = false;
     conval_called_with_current_x_ = false;
 }
+
+bool ASL_Repn::has_constraint_lower(size_t i)
+{    ASL_pfgh* asl = asl_;
+return LUrhs[i] > negInfinity; }
+
+bool ASL_Repn::has_constraint_upper(size_t i)
+{    ASL_pfgh* asl = asl_;
+return Urhsx[i] < Infinity; }
+
+double ASL_Repn::get_constraint_lower(size_t i)
+{    ASL_pfgh* asl = asl_;
+return LUrhs[i]; }
+
+double ASL_Repn::get_constraint_upper(size_t i)
+{    ASL_pfgh* asl = asl_;
+return Urhsx[i]; }
+
 
 void ASL_Repn::get_J_nonzeros(std::vector<size_t>& jrow, std::vector<size_t>& jcol)
 {
@@ -298,7 +315,7 @@ void ASL_Repn::alloc_asl()
     //
     // Create a temporary filename
     //
-    std::string fname = temp_directory + "coek_XXXXXX";
+    std::string fname = temp_directory + "/coek_XXXXXX";
     std::string tmp = mktemp(&fname[0]);
     if (tmp.size() == 0)
         throw std::runtime_error("Failure to create temporary file for ASL interface");
@@ -325,9 +342,13 @@ void ASL_Repn::alloc_asl()
             "ASL_Repn::alloc_asl - Cannot create ASL interface for model with no variables.");
     }
     //
-    // allocate space for initial values
+    // allocate space for data read in by pfgh_read()
     //
     X0 = new real[n_var];
+    LUv = new real[2*n_var];
+    //Uvx = new real[n_var];
+    LUrhs = new real[n_var];
+    Urhsx = new real[n_var];
     havex0 = new char[n_var];
     //
     // Load model expressions
@@ -336,7 +357,8 @@ void ASL_Repn::alloc_asl()
     //
     // Close and remove the file
     //
-    remove(fname.c_str());
+    if (remove_nl_file)
+        remove(fname.c_str());
 
     //
     // No errors, so return
@@ -375,6 +397,25 @@ void ASL_Repn::free_asl()
         if (X0) {
             delete[] X0;
             X0 = 0;
+        }
+
+        if (LUv) {
+            delete[] LUv;
+            LUv = 0;
+        }
+        /*
+        if (Uvx) {
+            delete[] Uvx;
+            Uvx = 0;
+        }
+        */
+        if (LUrhs) {
+            delete[] LUrhs;
+            LUrhs = 0;
+        }
+        if (Urhsx) {
+            delete[] Urhsx;
+            Urhsx = 0;
         }
 
         if (havex0) {
@@ -420,10 +461,25 @@ if (option == "temp_directory") {
 return false;
 }
 
+bool ASL_Repn::get_option(const std::string& option, int& value) const
+{
+if (option == "remove_nl_file") {
+    value = remove_nl_file;
+    return true;
+    }
+return false;
+}
+
 void ASL_Repn::set_option(const std::string& option, const std::string value)
 {
 if (option == "temp_directory")
     temp_directory = value;
+}
+
+void ASL_Repn::set_option(const std::string& option, int value)
+{
+if (option == "remove_nl_file")
+    remove_nl_file = value;
 }
 
 }  // namespace coek

--- a/lib/coek/coek/autograd/asl_repn.hpp
+++ b/lib/coek/coek/autograd/asl_repn.hpp
@@ -22,6 +22,8 @@ class ASL_Repn : public NLPModelRepn {
     ASL_pfgh* asl_;
     // The temporary file directory used to write the NL file
     std::string temp_directory;
+    // If set to 1, then the NL file is removed
+    int remove_nl_file = 1;
 
     // ----------------------------------------------------------------------
     // Problem information
@@ -75,6 +77,11 @@ class ASL_Repn : public NLPModelRepn {
     void set_variables(std::vector<double>& x);
     void set_variables(const double* x, size_t n);
 
+    bool has_constraint_lower(size_t i);
+    bool has_constraint_upper(size_t i);
+    double get_constraint_lower(size_t i);
+    double get_constraint_upper(size_t i);
+
     void get_J_nonzeros(std::vector<size_t>& jrow, std::vector<size_t>& jcol);
     void get_H_nonzeros(std::vector<size_t>& hrow, std::vector<size_t>& hcol);
     bool column_major_hessian();
@@ -97,7 +104,9 @@ class ASL_Repn : public NLPModelRepn {
 
    public:
     bool get_option(const std::string& option, std::string& value) const;
+    bool get_option(const std::string& option, int& value) const;
     void set_option(const std::string& option, const std::string value);
+    void set_option(const std::string& option, int value);
 
    protected:
     void* nerror_;

--- a/lib/coek/coek/autograd/autograd.cpp
+++ b/lib/coek/coek/autograd/autograd.cpp
@@ -88,17 +88,19 @@ Objective NLPModelRepn::get_objective(size_t i) { return model.get_objective(i);
 
 Constraint NLPModelRepn::get_constraint(size_t i) { return model.get_constraint(i); }
 
-bool NLPModelRepn::has_constraint_lower(size_t i)
-{ return model.get_constraint(i).has_lower(); }
+bool NLPModelRepn::has_constraint_lower(size_t i) { return model.get_constraint(i).has_lower(); }
 
-bool NLPModelRepn::has_constraint_upper(size_t i)
-{ return model.get_constraint(i).has_upper(); }
+bool NLPModelRepn::has_constraint_upper(size_t i) { return model.get_constraint(i).has_upper(); }
 
 double NLPModelRepn::get_constraint_lower(size_t i)
-{ return model.get_constraint(i).lower().value(); }
+{
+    return model.get_constraint(i).lower().value();
+}
 
 double NLPModelRepn::get_constraint_upper(size_t i)
-{ return model.get_constraint(i).upper().value(); }
+{
+    return model.get_constraint(i).upper().value();
+}
 
 void NLPModelRepn::print_equations(std::ostream& ostr) const
 {

--- a/lib/coek/coek/autograd/autograd.cpp
+++ b/lib/coek/coek/autograd/autograd.cpp
@@ -88,6 +88,18 @@ Objective NLPModelRepn::get_objective(size_t i) { return model.get_objective(i);
 
 Constraint NLPModelRepn::get_constraint(size_t i) { return model.get_constraint(i); }
 
+bool NLPModelRepn::has_constraint_lower(size_t i)
+{ return model.get_constraint(i).has_lower(); }
+
+bool NLPModelRepn::has_constraint_upper(size_t i)
+{ return model.get_constraint(i).has_upper(); }
+
+double NLPModelRepn::get_constraint_lower(size_t i)
+{ return model.get_constraint(i).lower().value(); }
+
+double NLPModelRepn::get_constraint_upper(size_t i)
+{ return model.get_constraint(i).upper().value(); }
+
 void NLPModelRepn::print_equations(std::ostream& ostr) const
 {
     ostr << "NLPModel:" << std::endl;

--- a/lib/coek/coek/autograd/autograd.hpp
+++ b/lib/coek/coek/autograd/autograd.hpp
@@ -37,7 +37,8 @@ class NLPModelRepn {
     virtual void set_variables(std::vector<double>& x) = 0;
     virtual void set_variables(const double* x, size_t n) = 0;
 
-    // TODO - Deprecate these methods!  The AD package may change the objective/constraint expressions
+    // TODO - Deprecate these methods!  The AD package may change the objective/constraint
+    // expressions
     virtual Objective get_objective(size_t i);
     virtual Constraint get_constraint(size_t i);
 
@@ -64,8 +65,7 @@ class NLPModelRepn {
    public:
     void find_used_variables();
 
-    public:
-
+   public:
     /** Get the value of an integer option
      *
      * The option value is returned by reference if it has
@@ -76,7 +76,7 @@ class NLPModelRepn {
      *
      * \returns \c true if the option is found
      */
-    virtual bool get_option(const std::string& /*option*/, int& /*value*/) const {return false;}
+    virtual bool get_option(const std::string& /*option*/, int& /*value*/) const { return false; }
     /** Get the value of a double option
      *
      * The option value is returned by reference if it has
@@ -87,7 +87,10 @@ class NLPModelRepn {
      *
      * \returns \c true if the option is found
      */
-    virtual bool get_option(const std::string& /*option*/, double& /*value*/) const {return false;}
+    virtual bool get_option(const std::string& /*option*/, double& /*value*/) const
+    {
+        return false;
+    }
     /** Get the value of a string option
      *
      * The option value is returned by reference if it has
@@ -98,7 +101,10 @@ class NLPModelRepn {
      *
      * \returns \c true if the option is found
      */
-    virtual bool get_option(const std::string& /*option*/, std::string& /*value*/) const { return false; }
+    virtual bool get_option(const std::string& /*option*/, std::string& /*value*/) const
+    {
+        return false;
+    }
 
     /** Set an integer option
      *
@@ -111,14 +117,13 @@ class NLPModelRepn {
      * \param option  the option name
      * \param value   the double value
      */
-    virtual void set_option(const std::string& /*option*/, double /*value*/) { }
+    virtual void set_option(const std::string& /*option*/, double /*value*/) {}
     /** Set a string option
      *
      * \param option  the option name
      * \param value   the string value
      */
-    virtual void set_option(const std::string& /*option*/, const std::string /*value*/) { }
-
+    virtual void set_option(const std::string& /*option*/, const std::string /*value*/) {}
 };
 
 NLPModelRepn* create_NLPModelRepn(Model& model, const std::string& name);

--- a/lib/coek/coek/autograd/autograd.hpp
+++ b/lib/coek/coek/autograd/autograd.hpp
@@ -37,8 +37,14 @@ class NLPModelRepn {
     virtual void set_variables(std::vector<double>& x) = 0;
     virtual void set_variables(const double* x, size_t n) = 0;
 
+    // TODO - Deprecate these methods!  The AD package may change the objective/constraint expressions
     virtual Objective get_objective(size_t i);
     virtual Constraint get_constraint(size_t i);
+
+    virtual bool has_constraint_lower(size_t i);
+    virtual bool has_constraint_upper(size_t i);
+    virtual double get_constraint_lower(size_t i);
+    virtual double get_constraint_upper(size_t i);
 
     virtual void print_equations(std::ostream& ostr) const = 0;
     virtual void print_values(std::ostream& ostr) const = 0;

--- a/lib/coek/coek/autograd/cppad_repn.cpp
+++ b/lib/coek/coek/autograd/cppad_repn.cpp
@@ -591,19 +591,17 @@ void CppAD_Repn::reset(void)
 
 bool CppAD_Repn::get_option(const std::string& option, int& value) const
 {
-if (option == "sparse_JH") {
-    value = sparse_JH;
-    return true;
+    if (option == "sparse_JH") {
+        value = sparse_JH;
+        return true;
     }
-return false;
+    return false;
 }
 
 void CppAD_Repn::set_option(const std::string& option, int value)
 {
-if (option == "sparse_JH")
-    sparse_JH = (value==1);
+    if (option == "sparse_JH") sparse_JH = (value == 1);
 }
-
 
 //
 // This empty namespace contains functions used to walk the COEK

--- a/lib/coek/coek/autograd/cppad_repn.hpp
+++ b/lib/coek/coek/autograd/cppad_repn.hpp
@@ -127,7 +127,6 @@ class CppAD_Repn : public NLPModelRepn {
     void compute_J(std::vector<double>& J);
 
    public:
-
     bool get_option(const std::string& option, int& value) const;
 
     void set_option(const std::string& option, int value);

--- a/lib/coek/coek/model/nlp_model.cpp
+++ b/lib/coek/coek/model/nlp_model.cpp
@@ -12,52 +12,52 @@ namespace coek {
 //
 
 class OptionCacheRepn {
-public:
+   public:
     std::map<std::string, std::string> string_options;
     std::map<std::string, int> integer_options;
     std::map<std::string, double> double_options;
 };
 
-OptionCache::OptionCache()
-{
-    options = std::make_shared<OptionCacheRepn>();
-}
+OptionCache::OptionCache() { options = std::make_shared<OptionCacheRepn>(); }
 
 bool OptionCache::get_option(const std::string& option, int& value) const
 {
-auto it = options->integer_options.find(option);
-if (it == options->integer_options.end())
-    return false;
-value = it->second;
-return true;
+    auto it = options->integer_options.find(option);
+    if (it == options->integer_options.end()) return false;
+    value = it->second;
+    return true;
 }
 
 bool OptionCache::get_option(const std::string& option, double& value) const
 {
-auto it = options->double_options.find(option);
-if (it == options->double_options.end())
-    return false;
-value = it->second;
-return true;
+    auto it = options->double_options.find(option);
+    if (it == options->double_options.end()) return false;
+    value = it->second;
+    return true;
 }
 
 bool OptionCache::get_option(const std::string& option, std::string& value) const
 {
-auto it = options->string_options.find(option);
-if (it == options->string_options.end())
-    return false;
-value = it->second;
-return true;
+    auto it = options->string_options.find(option);
+    if (it == options->string_options.end()) return false;
+    value = it->second;
+    return true;
 }
 
 void OptionCache::set_option(const std::string& option, int value)
-{ options->integer_options[option] = value; }
+{
+    options->integer_options[option] = value;
+}
 
 void OptionCache::set_option(const std::string& option, double value)
-{ options->double_options[option] = value; }
+{
+    options->double_options[option] = value;
+}
 
 void OptionCache::set_option(const std::string& option, const std::string value)
-{ options->string_options[option] = value; }
+{
+    options->string_options[option] = value;
+}
 
 //
 // NLPModel
@@ -69,21 +69,18 @@ NLPModel::NLPModel()
     repn = tmp;
 }
 
-NLPModel::NLPModel(Model& model, std::string type)
-{
-    initialize(model, type);
-}
+NLPModel::NLPModel(Model& model, std::string type) { initialize(model, type); }
 
 void NLPModel::initialize(Model& model, std::string type)
 {
     std::shared_ptr<NLPModelRepn> tmp(create_NLPModelRepn(model, type));
     repn = tmp;
 
-    for (const auto& ioption: options->integer_options)
+    for (const auto& ioption : options->integer_options)
         repn->set_option(ioption.first, ioption.second);
-    for (const auto& doption: options->double_options)
+    for (const auto& doption : options->double_options)
         repn->set_option(doption.first, doption.second);
-    for (const auto& soption: options->string_options)
+    for (const auto& soption : options->string_options)
         repn->set_option(soption.first, soption.second);
 
     repn->initialize();
@@ -114,15 +111,10 @@ Objective NLPModel::get_objective(size_t i) { return repn->get_objective(i); }
 
 Constraint NLPModel::get_constraint(size_t i) { return repn->get_constraint(i); }
 
-bool NLPModel::has_constraint_lower(size_t i)
-{return repn->has_constraint_lower(i);}
-bool NLPModel::has_constraint_upper(size_t i)
-{return repn->has_constraint_upper(i);}
-double NLPModel::get_constraint_lower(size_t i)
-{return repn->get_constraint_lower(i);}
-double NLPModel::get_constraint_upper(size_t i)
-{return repn->get_constraint_upper(i);}
-
+bool NLPModel::has_constraint_lower(size_t i) { return repn->has_constraint_lower(i); }
+bool NLPModel::has_constraint_upper(size_t i) { return repn->has_constraint_upper(i); }
+double NLPModel::get_constraint_lower(size_t i) { return repn->get_constraint_lower(i); }
+double NLPModel::get_constraint_upper(size_t i) { return repn->get_constraint_upper(i); }
 
 void NLPModel::get_J_nonzeros(std::vector<size_t>& jrow, std::vector<size_t>& jcol)
 {

--- a/lib/coek/coek/model/nlp_model.cpp
+++ b/lib/coek/coek/model/nlp_model.cpp
@@ -114,6 +114,16 @@ Objective NLPModel::get_objective(size_t i) { return repn->get_objective(i); }
 
 Constraint NLPModel::get_constraint(size_t i) { return repn->get_constraint(i); }
 
+bool NLPModel::has_constraint_lower(size_t i)
+{return repn->has_constraint_lower(i);}
+bool NLPModel::has_constraint_upper(size_t i)
+{return repn->has_constraint_upper(i);}
+double NLPModel::get_constraint_lower(size_t i)
+{return repn->get_constraint_lower(i);}
+double NLPModel::get_constraint_upper(size_t i)
+{return repn->get_constraint_upper(i);}
+
+
 void NLPModel::get_J_nonzeros(std::vector<size_t>& jrow, std::vector<size_t>& jcol)
 {
     repn->get_J_nonzeros(jrow, jcol);

--- a/lib/coek/coek/model/nlp_model.hpp
+++ b/lib/coek/coek/model/nlp_model.hpp
@@ -117,10 +117,16 @@ class NLPModel : public OptionCache {
     /** Sets the value of variables used in the model view */
     void set_variable_view(const double* x, size_t n);
 
+    // TODO - Deprecate these two methods
     /** \returns the i-th objective in the model view */
     Objective get_objective(size_t i);
     /** \returns the i-th constraint in the model view */
     Constraint get_constraint(size_t i);
+
+    bool has_constraint_lower(size_t i);
+    bool has_constraint_upper(size_t i);
+    double get_constraint_lower(size_t i);
+    double get_constraint_upper(size_t i);
 
     /**
      * Return the row and column indices of the Jacobian nonzeros.

--- a/lib/coek/coek/model/nlp_model.hpp
+++ b/lib/coek/coek/model/nlp_model.hpp
@@ -11,8 +11,7 @@ class OptionCache {
    public:
     std::shared_ptr<OptionCacheRepn> options;
 
-    public:
-
+   public:
     OptionCache();
 
     /** Get the value of an integer option
@@ -68,7 +67,6 @@ class OptionCache {
      */
     void set_option(const std::string& option, const std::string value);
 };
-
 
 /**
  * An optimization model that provides a view of a coek::Model

--- a/lib/coek/coek/solvers/ipopt/ipopt_capi.cpp
+++ b/lib/coek/coek/solvers/ipopt/ipopt_capi.cpp
@@ -187,6 +187,17 @@ bool IpoptModel::get_bounds_info(Index /*n*/, Number* x_l, Number* x_u, Index /*
     }
 
     // std::cout << "  num constraints: " << nlpmodel.num_constraints() << std::endl;
+    for (size_t j : coek::range(nlpmodel.num_constraints())) {
+        if (nlpmodel.has_constraint_lower(j))
+            g_l[j] = nlpmodel.get_constraint_lower(j);
+        else
+            g_l[j] = -COEK_INFINITY;
+        if (nlpmodel.has_constraint_upper(j))
+            g_u[j] = nlpmodel.get_constraint_upper(j);
+        else
+            g_u[j] = COEK_INFINITY;
+        }
+/*
     for (size_t j = 0; j < nlpmodel.repn->model.repn->constraints.size(); j++) {
         auto& con = nlpmodel.repn->model.repn->constraints[j];
         if (con.is_inequality()) {
@@ -205,6 +216,7 @@ bool IpoptModel::get_bounds_info(Index /*n*/, Number* x_l, Number* x_u, Index /*
             // std::cout << "g " << j << " " << g_l[j] << " " << g_u[j] << std::endl << std::flush;
         }
     }
+*/
 
     return true;
 }

--- a/lib/coek/coek/solvers/ipopt/ipopt_capi.cpp
+++ b/lib/coek/coek/solvers/ipopt/ipopt_capi.cpp
@@ -196,27 +196,29 @@ bool IpoptModel::get_bounds_info(Index /*n*/, Number* x_l, Number* x_u, Index /*
             g_u[j] = nlpmodel.get_constraint_upper(j);
         else
             g_u[j] = COEK_INFINITY;
-        }
-/*
-    for (size_t j = 0; j < nlpmodel.repn->model.repn->constraints.size(); j++) {
-        auto& con = nlpmodel.repn->model.repn->constraints[j];
-        if (con.is_inequality()) {
-            if (con.has_lower())
-                g_l[j] = con.lower().value();
-            else
-                g_l[j] = -COEK_INFINITY;
-            if (con.has_upper())
-                g_u[j] = con.upper().value();
-            else
-                g_u[j] = COEK_INFINITY;
-            // std::cout << "g " << j << " " << g_l[j] << " " << g_u[j] << std::endl << std::flush;
-        }
-        else {
-            g_l[j] = g_u[j] = con.lower().value();
-            // std::cout << "g " << j << " " << g_l[j] << " " << g_u[j] << std::endl << std::flush;
-        }
     }
-*/
+    /*
+        for (size_t j = 0; j < nlpmodel.repn->model.repn->constraints.size(); j++) {
+            auto& con = nlpmodel.repn->model.repn->constraints[j];
+            if (con.is_inequality()) {
+                if (con.has_lower())
+                    g_l[j] = con.lower().value();
+                else
+                    g_l[j] = -COEK_INFINITY;
+                if (con.has_upper())
+                    g_u[j] = con.upper().value();
+                else
+                    g_u[j] = COEK_INFINITY;
+                // std::cout << "g " << j << " " << g_l[j] << " " << g_u[j] << std::endl <<
+       std::flush;
+            }
+            else {
+                g_l[j] = g_u[j] = con.lower().value();
+                // std::cout << "g " << j << " " << g_l[j] << " " << g_u[j] << std::endl <<
+       std::flush;
+            }
+        }
+    */
 
     return true;
 }

--- a/lib/coek/test/mt_funcs.cpp
+++ b/lib/coek/test/mt_funcs.cpp
@@ -6,57 +6,55 @@
 
 coek::Model srosenbr_vector();
 
-//void _eval_model(size_t thread_id, size_t niters, coek::NLPModel& f_min) {}
+// void _eval_model(size_t thread_id, size_t niters, coek::NLPModel& f_min) {}
 
 void eval_model(size_t thread_id, size_t niters, coek::NLPModel& nlp, double& f_min)
 {
-std::mt19937 gen(123456789 + thread_id);
-std::uniform_real_distribution<> urand(-1.0, 1.0);
-std::vector<double> x(nlp.num_variables());
+    std::mt19937 gen(123456789 + thread_id);
+    std::uniform_real_distribution<> urand(-1.0, 1.0);
+    std::vector<double> x(nlp.num_variables());
 
-double f;
-std::vector<double> df(nlp.num_variables());
+    double f;
+    std::vector<double> df(nlp.num_variables());
 
-f_min = std::numeric_limits<double>::max();
-for (auto i : coek::range(niters) ) {
-    for (double& val : x)
-        val = urand(gen);
+    f_min = std::numeric_limits<double>::max();
+    for (auto i : coek::range(niters)) {
+        for (double& val : x) val = urand(gen);
 
-    nlp.set_variable_view(x);
-    nlp.compute_df(f, df);
-    f_min = std::min(f, f_min);
+        nlp.set_variable_view(x);
+        nlp.compute_df(f, df);
+        f_min = std::min(f, f_min);
     }
 }
 
 //
 // Randomly search for low values of srosenbr across nthreads
 //
-double test_srosenbr_vector_threadeval(const std::string& asl_type, size_t nthreads, size_t niters, double timelimit)
+double test_srosenbr_vector_threadeval(const std::string& asl_type, size_t nthreads, size_t niters,
+                                       double timelimit)
 {
-std::vector<double> f_min(nthreads);
+    std::vector<double> f_min(nthreads);
 
-//
-// Allocate models before creating threads
-//
-std::vector<coek::NLPModel> models;
-for (auto i : coek::range(nthreads)) {
-    coek::Model tmp = srosenbr_vector();
-    models.emplace_back( coek::NLPModel(tmp, asl_type) );
+    //
+    // Allocate models before creating threads
+    //
+    std::vector<coek::NLPModel> models;
+    for (auto i : coek::range(nthreads)) {
+        coek::Model tmp = srosenbr_vector();
+        models.emplace_back(coek::NLPModel(tmp, asl_type));
     }
 
-//
-// Create threads and start them
-//
-std::vector<std::thread> threads;
-for (size_t i : coek::range(nthreads)) {
-    threads.emplace_back( eval_model, i, niters, std::ref(models[i]), std::ref(f_min[i]) );
+    //
+    // Create threads and start them
+    //
+    std::vector<std::thread> threads;
+    for (size_t i : coek::range(nthreads)) {
+        threads.emplace_back(eval_model, i, niters, std::ref(models[i]), std::ref(f_min[i]));
     }
-//
-// Join the threads
-//
-for (auto& t : threads)
-    t.join();
+    //
+    // Join the threads
+    //
+    for (auto& t : threads) t.join();
 
-return *min_element(f_min.begin(), f_min.end());
+    return *min_element(f_min.begin(), f_min.end());
 }
-

--- a/lib/coek/test/test_autograd_asl.cpp
+++ b/lib/coek/test/test_autograd_asl.cpp
@@ -1210,14 +1210,15 @@ TEST_CASE("asl_diff_tests", "[smoke]")
     }
 }
 
-double test_srosenbr_vector_threadeval(const std::string& asl_type, size_t nthreads, size_t niters, double timelimit);
+double test_srosenbr_vector_threadeval(const std::string& asl_type, size_t nthreads, size_t niters,
+                                       double timelimit);
 
 TEST_CASE("asl_mt", "[smoke]")
 {
     SECTION("srosenbr")
     {
         double tmp = test_srosenbr_vector_threadeval(ADNAME, 10, 100, 30);
-        //REQUIRE(tmp == Approx(262080.5003334123));   nthreads = 2
-        REQUIRE(tmp == Approx(260040.0242064819));      // nthreads=2 niters=100
+        // REQUIRE(tmp == Approx(262080.5003334123));   nthreads = 2
+        REQUIRE(tmp == Approx(260040.0242064819));  // nthreads=2 niters=100
     }
 }

--- a/lib/coek/test/test_examples.cpp
+++ b/lib/coek/test/test_examples.cpp
@@ -30,41 +30,42 @@ std::vector<double> invquad_soln_5{-10, -10, -10, -10, -10};
 // bounds_check
 coek::Model check_bounds()
 {
-coek::Model model;
+    coek::Model model;
 
-auto a = model.add_variable().value(2.0);
-auto b = model.add_variable().value(-2.0);
-auto c = model.add_variable().value(2.0);
-auto d = model.add_variable().value(-2.0);
-auto e = model.add_variable().value(2.0);
+    auto a = model.add_variable().value(2.0);
+    auto b = model.add_variable().value(-2.0);
+    auto c = model.add_variable().value(2.0);
+    auto d = model.add_variable().value(-2.0);
+    auto e = model.add_variable().value(2.0);
 
-auto aa = model.add_variable().value(2.0);
-auto bb = model.add_variable().value(-2.0);
-auto cc = model.add_variable().value(2.0);
-auto dd = model.add_variable().value(-2.0);
-auto ee = model.add_variable().value(2.0);
+    auto aa = model.add_variable().value(2.0);
+    auto bb = model.add_variable().value(-2.0);
+    auto cc = model.add_variable().value(2.0);
+    auto dd = model.add_variable().value(-2.0);
+    auto ee = model.add_variable().value(2.0);
 
-model.add_objective( a*a+b*b+c*c+d*d );
+    model.add_objective(a * a + b * b + c * c + d * d);
 
-model.add( a >= 1 );
-model.add( b <= -1 );
-model.add( aa - 1 >= 0 );
-model.add( bb + 1 <= 0 );
-model.add( inequality(1, c, 3) );
-model.add( inequality(-3, d, -1) );
-model.add( inequality(0, cc-1, 2) );
-model.add( inequality(-2, dd+1, 0) );
-model.add( e == 1 );
-model.add( ee - 1 == 0 );
+    model.add(a >= 1);
+    model.add(b <= -1);
+    model.add(aa - 1 >= 0);
+    model.add(bb + 1 <= 0);
+    model.add(inequality(1, c, 3));
+    model.add(inequality(-3, d, -1));
+    model.add(inequality(0, cc - 1, 2));
+    model.add(inequality(-2, dd + 1, 0));
+    model.add(e == 1);
+    model.add(ee - 1 == 0);
 
-return model;
+    return model;
 }
 std::vector<double> check_bounds_soln{1, -1, 1, -1, 1, -1, 1};
 
-
 void check(std::vector<coek::Variable>& variables, std::vector<double>& soln)
 {
-    for (size_t i = 0; i < variables.size(); i++) { REQUIRE(variables[i].value() == Approx(soln[i])); }
+    for (size_t i = 0; i < variables.size(); i++) {
+        REQUIRE(variables[i].value() == Approx(soln[i]));
+    }
 }
 
 TEST_CASE("ipopt_cppad", "[smoke]")

--- a/lib/coek/test/test_examples.cpp
+++ b/lib/coek/test/test_examples.cpp
@@ -8,13 +8,17 @@
 //
 // EXAMPLES
 //
+
+// rosenbr
 coek::Model rosenbr();
 std::vector<double> rosenbr_soln{1, 1};
 
+// simplelp1
 coek::Model simplelp1();
 std::vector<double> simplelp1_soln{375, 250};
 void simplelp1_solve();
 
+// invquad
 coek::Model invquad_vector(std::vector<coek::Parameter>& p);
 #if __cpp_lib_variant
 coek::Model invquad_array(std::vector<coek::Parameter>& p);
@@ -23,9 +27,44 @@ void invquad_array_resolve();
 #endif
 std::vector<double> invquad_soln_5{-10, -10, -10, -10, -10};
 
+// bounds_check
+coek::Model check_bounds()
+{
+coek::Model model;
+
+auto a = model.add_variable().value(2.0);
+auto b = model.add_variable().value(-2.0);
+auto c = model.add_variable().value(2.0);
+auto d = model.add_variable().value(-2.0);
+auto e = model.add_variable().value(2.0);
+
+auto aa = model.add_variable().value(2.0);
+auto bb = model.add_variable().value(-2.0);
+auto cc = model.add_variable().value(2.0);
+auto dd = model.add_variable().value(-2.0);
+auto ee = model.add_variable().value(2.0);
+
+model.add_objective( a*a+b*b+c*c+d*d );
+
+model.add( a >= 1 );
+model.add( b <= -1 );
+model.add( aa - 1 >= 0 );
+model.add( bb + 1 <= 0 );
+model.add( inequality(1, c, 3) );
+model.add( inequality(-3, d, -1) );
+model.add( inequality(0, cc-1, 2) );
+model.add( inequality(-2, dd+1, 0) );
+model.add( e == 1 );
+model.add( ee - 1 == 0 );
+
+return model;
+}
+std::vector<double> check_bounds_soln{1, -1, 1, -1, 1, -1, 1};
+
+
 void check(std::vector<coek::Variable>& variables, std::vector<double>& soln)
 {
-    for (size_t i = 0; i < variables.size(); i++) REQUIRE(variables[i].value() == Approx(soln[i]));
+    for (size_t i = 0; i < variables.size(); i++) { REQUIRE(variables[i].value() == Approx(soln[i])); }
 }
 
 TEST_CASE("ipopt_cppad", "[smoke]")
@@ -45,6 +84,16 @@ TEST_CASE("ipopt_cppad", "[smoke]")
             solver.solve(nlp);
 
             check(m.get_variables(), rosenbr_soln);
+        }
+
+        SECTION("check_bounds")
+        {
+            auto m = check_bounds();
+
+            coek::NLPModel nlp(m, "cppad");
+            solver.solve(nlp);
+
+            check(m.get_variables(), check_bounds_soln);
         }
 
         SECTION("invquad_vector")
@@ -212,6 +261,16 @@ TEST_CASE("ipopt_asl", "[smoke]")
             solver.solve(nlp);
 
             check(m.get_variables(), rosenbr_soln);
+        }
+
+        SECTION("check_bounds")
+        {
+            auto m = check_bounds();
+
+            coek::NLPModel nlp(m, "asl");
+            solver.solve(nlp);
+
+            check(m.get_variables(), check_bounds_soln);
         }
 
         SECTION("invquad_vector")


### PR DESCRIPTION
Resolved a problem where the constraint bounds in ipopt were not being properly set.

Fundamentally, the problem is that ASL changed the constraint expressions, unless CppAD.  This necessitated a change in the autograd API to force the explicit management of constraint bounds information.