### PR TITLE
Removing the Visitor logic

### DIFF
--- a/lib/coek/coek/ast/base_terms.hpp
+++ b/lib/coek/coek/ast/base_terms.hpp
@@ -10,7 +10,6 @@
 
 namespace coek {
 
-class Visitor;
 class BaseExpressionTerm;
 
 // SHARED_PTR
@@ -36,7 +35,6 @@ class BaseExpressionTerm {
 
     virtual expr_pointer_t const_mult(double coef, const expr_pointer_t& repn);
     virtual expr_pointer_t negate(const expr_pointer_t& repn);
-    virtual void accept(Visitor& v) = 0;
     virtual term_id id() = 0;
     std::list<std::string> to_list();
 };
@@ -57,7 +55,6 @@ class ConstantTerm : public BaseExpressionTerm {
 
     expr_pointer_t negate(const expr_pointer_t& repn);
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return ConstantTerm_id; }
 };
 

--- a/lib/coek/coek/ast/compact_terms.hpp
+++ b/lib/coek/coek/ast/compact_terms.hpp
@@ -21,7 +21,6 @@ class ParameterRefTerm : public BaseParameterTerm {
                      void* _param);
 
     double _eval() const { throw std::runtime_error("Cannot evaluate a ParameterRefTerm"); }
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return ParameterRefTerm_id; }
 };
 
@@ -36,7 +35,6 @@ class VariableRefTerm : public BaseVariableTerm {
                     void* _var);
 
     double _eval() const { throw std::runtime_error("Cannot evaluate a VariableRefTerm"); }
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return VariableRefTerm_id; }
 };
 

--- a/lib/coek/coek/ast/constraint_terms.hpp
+++ b/lib/coek/coek/ast/constraint_terms.hpp
@@ -25,7 +25,6 @@ class ObjectiveTerm : public BaseExpressionTerm {
 
     double _eval() const { return body->_eval(); }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return ObjectiveTerm_id; }
 
     virtual std::string get_simple_name() { return "O[" + std::to_string(index) + "]"; }
@@ -115,7 +114,6 @@ class InequalityTerm : public ConstraintTerm {
         }
     }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return InequalityTerm_id; }
 };
 
@@ -129,7 +127,6 @@ class EqualityTerm : public ConstraintTerm {
     bool is_equality() const { return true; }
     bool is_feasible() const { return body->eval() == lower->eval(); }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return EqualityTerm_id; }
 };
 
@@ -139,7 +136,6 @@ class EmptyConstraintTerm : public ConstraintTerm {
 
     bool is_feasible() const { return true; }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return EmptyConstraintTerm_id; }
 };
 

--- a/lib/coek/coek/ast/expr_terms.hpp
+++ b/lib/coek/coek/ast/expr_terms.hpp
@@ -104,7 +104,6 @@ class SubExpressionTerm : public UnaryTerm {
             return name;
     }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return SubExpressionTerm_id; }
 };
 
@@ -118,7 +117,6 @@ class NegateTerm : public UnaryTerm {
 
     double _eval() const { return -body->_eval(); }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return NegateTerm_id; }
 };
 
@@ -140,7 +138,6 @@ class PlusTerm : public NAryPrefixTerm {
         return ans;
     }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return PlusTerm_id; }
 };
 
@@ -154,7 +151,6 @@ class TimesTerm : public BinaryTerm {
 
     double _eval() const { return lhs->_eval() * rhs->_eval(); }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return TimesTerm_id; }
 };
 
@@ -168,7 +164,6 @@ class DivideTerm : public BinaryTerm {
 
     double _eval() const { return lhs->_eval() / rhs->_eval(); }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return DivideTerm_id; }
 };
 
@@ -183,7 +178,6 @@ class DivideTerm : public BinaryTerm {
                                                                        \
         double _eval() const { return ::FN(body->_eval()); }           \
                                                                        \
-        void accept(Visitor& v) { v.visit(*this); }                    \
         term_id id() { return TERM##_id; }                             \
     };
 
@@ -231,7 +225,6 @@ UNARY_CLASS(atanh, ATanhTerm)
                                                                                              \
         double _eval() const { return ::FN(lhs->_eval(), rhs->_eval()); }                    \
                                                                                              \
-        void accept(Visitor& v) { v.visit(*this); }                                          \
         term_id id() { return TERM##_id; }                                                   \
     };
 
@@ -254,7 +247,6 @@ class IfThenElseTerm : public ExpressionTerm {
 
     double _eval() const { return cond_expr->_eval() ? then_expr->_eval() : else_expr->_eval(); }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return IfThenElseTerm_id; }
 
     size_t num_expressions() const { return 3; }
@@ -266,6 +258,22 @@ class IfThenElseTerm : public ExpressionTerm {
             return then_expr;
         return else_expr;
     }
+};
+
+//
+// Class used in NL writer
+//
+class DefinedValueTerm : public BaseExpressionTerm {
+   public:
+    unsigned int index = 0;
+
+    DefinedValueTerm(unsigned int _index) : index(_index) {}
+
+    bool is_expression() const { return true; }
+
+    double _eval() const { return 0.0; }
+
+    term_id id() { return DefinedValueTerm_id; }
 };
 
 }  // namespace coek

--- a/lib/coek/coek/ast/value_terms.hpp
+++ b/lib/coek/coek/ast/value_terms.hpp
@@ -35,7 +35,6 @@ class ParameterTerm : public BaseParameterTerm {
 
     expr_pointer_t negate(const expr_pointer_t& repn);
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return ParameterTerm_id; }
 
     void set_value(double val);
@@ -83,7 +82,6 @@ class IndexParameterTerm : public BaseExpressionTerm {
 
     expr_pointer_t negate(const expr_pointer_t& repn);
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return IndexParameterTerm_id; }
 };
 
@@ -125,7 +123,6 @@ class VariableTerm : public BaseVariableTerm {
     expr_pointer_t const_mult(double coef, const expr_pointer_t& repn);
     expr_pointer_t negate(const expr_pointer_t& repn);
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return VariableTerm_id; }
 
     virtual std::string get_simple_name() { return "X[" + std::to_string(index) + "]"; }
@@ -165,7 +162,6 @@ class MonomialTerm : public BaseExpressionTerm {
 
     expr_pointer_t negate(const expr_pointer_t& repn);
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return MonomialTerm_id; }
 };
 

--- a/lib/coek/coek/ast/visitor.hpp
+++ b/lib/coek/coek/ast/visitor.hpp
@@ -1,123 +1,15 @@
 #pragma once
 
-#ifdef __has_include
-#    if __has_include(<version>)
-#        include <version>
-#    endif
-#endif
-#if __cpp_lib_variant
-#    include <variant>
-#endif
-
-#include <stdexcept>
-
 namespace coek {
-
-class BaseExpressionTerm;
-class VariableTerm;
-#if __cpp_lib_variant
-class ParameterRefTerm;
-class VariableRefTerm;
-#endif
-class ConstantTerm;
-class ParameterTerm;
-class IndexParameterTerm;
-class MonomialTerm;
-class InequalityTerm;
-class EqualityTerm;
-class EmptyConstraintTerm;
-class SubExpressionTerm;
-class NegateTerm;
-class PlusTerm;
-class TimesTerm;
-class DivideTerm;
-class AbsTerm;
-class CeilTerm;
-class FloorTerm;
-class ExpTerm;
-class LogTerm;
-class Log10Term;
-class SqrtTerm;
-class SinTerm;
-class CosTerm;
-class TanTerm;
-class SinhTerm;
-class CoshTerm;
-class TanhTerm;
-class ASinTerm;
-class ACosTerm;
-class ATanTerm;
-class ASinhTerm;
-class ACoshTerm;
-class ATanhTerm;
-class PowTerm;
-class SumExpressionTerm;
-class ObjectiveTerm;
-class IfThenElseTerm;
-
-class Visitor {
-   public:
-    virtual ~Visitor() {}
-
-    virtual void visit(ConstantTerm& arg) = 0;
-    virtual void visit(ParameterTerm& arg) = 0;
-    virtual void visit(IndexParameterTerm& arg) = 0;
-    virtual void visit(VariableTerm& arg) = 0;
-#if __cpp_lib_variant
-    virtual void visit(ParameterRefTerm& arg) = 0;
-    virtual void visit(VariableRefTerm& arg) = 0;
-#endif
-    virtual void visit(MonomialTerm& arg) = 0;
-    virtual void visit(InequalityTerm& arg) = 0;
-    virtual void visit(EqualityTerm& arg) = 0;
-    virtual void visit(EmptyConstraintTerm&) {}
-    virtual void visit(SubExpressionTerm& arg) = 0;
-    virtual void visit(NegateTerm& arg) = 0;
-    virtual void visit(PlusTerm& arg) = 0;
-    virtual void visit(TimesTerm& arg) = 0;
-    virtual void visit(DivideTerm& arg) = 0;
-    virtual void visit(AbsTerm& arg) = 0;
-    virtual void visit(CeilTerm& arg) = 0;
-    virtual void visit(FloorTerm& arg) = 0;
-    virtual void visit(ExpTerm& arg) = 0;
-    virtual void visit(LogTerm& arg) = 0;
-    virtual void visit(Log10Term& arg) = 0;
-    virtual void visit(SqrtTerm& arg) = 0;
-    virtual void visit(SinTerm& arg) = 0;
-    virtual void visit(CosTerm& arg) = 0;
-    virtual void visit(TanTerm& arg) = 0;
-    virtual void visit(SinhTerm& arg) = 0;
-    virtual void visit(CoshTerm& arg) = 0;
-    virtual void visit(TanhTerm& arg) = 0;
-    virtual void visit(ASinTerm& arg) = 0;
-    virtual void visit(ACosTerm& arg) = 0;
-    virtual void visit(ATanTerm& arg) = 0;
-    virtual void visit(ASinhTerm& arg) = 0;
-    virtual void visit(ACoshTerm& arg) = 0;
-    virtual void visit(ATanhTerm& arg) = 0;
-    virtual void visit(PowTerm& arg) = 0;
-    virtual void visit(ObjectiveTerm& arg) = 0;
-    virtual void visit(SumExpressionTerm&)
-    {
-        throw std::runtime_error("Visitor cannot handle SumExpressionTerm");
-    }
-    virtual void visit(IfThenElseTerm&) = 0;
-};
 
 enum term_id : unsigned int {
     ConstantTerm_id = 1,
     ParameterTerm_id = 2,
-    ParameterRefTerm_id = 106,
-    IndexParameterTerm_id = 100,
     VariableTerm_id = 3,
     VariableRefTerm_id = 4,
-    // IndexedVariableTerm_id = 101,
     MonomialTerm_id = 5,
     InequalityTerm_id = 6,
     EqualityTerm_id = 7,
-    EmptyConstraintTerm_id = 104,
-    // EmptyObjectiveTerm_id = 105,
-    SubExpressionTerm_id = 107,
     NegateTerm_id = 8,
     PlusTerm_id = 9,
     TimesTerm_id = 10,
@@ -142,9 +34,16 @@ enum term_id : unsigned int {
     ACoshTerm_id = 29,
     ATanhTerm_id = 30,
     PowTerm_id = 31,
+    IndexParameterTerm_id = 100,
+    // IndexedVariableTerm_id = 101,
     SumExpressionTerm_id = 102,
     ObjectiveTerm_id = 103,
+    EmptyConstraintTerm_id = 104,
+    // EmptyObjectiveTerm_id = 105,
+    ParameterRefTerm_id = 106,
+    SubExpressionTerm_id = 107,
     IfThenElseTerm_id = 108,
+    DefinedValueTerm_id = 109,
 };
 
 }  // namespace coek

--- a/lib/coek/coek/ast/visitor_fns.hpp
+++ b/lib/coek/coek/ast/visitor_fns.hpp
@@ -12,16 +12,10 @@ class ParameterTerm;
 class SubExpressionTerm;
 
 void expr_to_list(BaseExpressionTerm* expr, std::list<std::string>& repr);
-inline void expr_to_list(const expr_pointer_t& expr, std::list<std::string>& repr)
-{
-    expr_to_list(expr.get(), repr);
-}
+void expr_to_list(const expr_pointer_t& expr, std::list<std::string>& repr);
 
 void write_expr(BaseExpressionTerm* expr, std::ostream& ostr);
-inline void write_expr(const expr_pointer_t& expr, std::ostream& ostr)
-{
-    write_expr(expr.get(), ostr);
-}
+void write_expr(const expr_pointer_t& expr, std::ostream& ostr);
 
 void symbolic_diff_all(const expr_pointer_t& expr,
                        std::map<std::shared_ptr<VariableTerm>, expr_pointer_t>& diff);

--- a/lib/coek/coek/ast/visitor_to_list.cpp
+++ b/lib/coek/coek/ast/visitor_to_list.cpp
@@ -9,216 +9,192 @@
 #if __cpp_lib_variant
 #    include "compact_terms.hpp"
 #endif
+#include "coek/util/cast_utils.hpp"
 
 namespace coek {
 
 namespace {
 
-class ToListVisitor : public Visitor {
-   public:
-    std::list<std::string>& repr;
+void visit_expression(const expr_pointer_t& expr, std::list<std::string>& repr);
 
-   public:
-    ToListVisitor(std::list<std::string>& _repr) : repr(_repr) {}
-
-    void visit(ConstantTerm& arg);
-    void visit(ParameterTerm& arg);
-    void visit(IndexParameterTerm& arg);
-    void visit(VariableTerm& arg);
-#if __cpp_lib_variant
-    void visit(ParameterRefTerm& arg);
-    void visit(VariableRefTerm& arg);
-#endif
-    void visit(MonomialTerm& arg);
-    void visit(InequalityTerm& arg);
-    void visit(EqualityTerm& arg);
-    void visit(ObjectiveTerm& arg);
-    void visit(SubExpressionTerm& arg);
-    void visit(NegateTerm& arg);
-    void visit(PlusTerm& arg);
-    void visit(TimesTerm& arg);
-    void visit(DivideTerm& arg);
-    void visit(AbsTerm& arg);
-    void visit(CeilTerm& arg);
-    void visit(FloorTerm& arg);
-    void visit(ExpTerm& arg);
-    void visit(LogTerm& arg);
-    void visit(Log10Term& arg);
-    void visit(SqrtTerm& arg);
-    void visit(SinTerm& arg);
-    void visit(CosTerm& arg);
-    void visit(TanTerm& arg);
-    void visit(SinhTerm& arg);
-    void visit(CoshTerm& arg);
-    void visit(TanhTerm& arg);
-    void visit(ASinTerm& arg);
-    void visit(ACosTerm& arg);
-    void visit(ATanTerm& arg);
-    void visit(ASinhTerm& arg);
-    void visit(ACoshTerm& arg);
-    void visit(ATanhTerm& arg);
-    void visit(PowTerm& arg);
-    void visit(SumExpressionTerm& arg);
-    void visit(IfThenElseTerm& arg);
-};
-
-void ToListVisitor::visit(ConstantTerm& arg)
+void visit_ConstantTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
-    // std::stringstream sstr;
-    // char c[256];
-    // std::snprintf(c, 256, "%.3f", arg.value);
-    repr.push_back(std::to_string(arg.value));
+    auto tmp = safe_pointer_cast<ConstantTerm>(expr);
+    repr.push_back(std::to_string(tmp->value));
 }
 
-void ToListVisitor::visit(ParameterTerm& arg)
+void visit_ParameterTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<ParameterTerm>(expr);
     std::stringstream sstr;
-    write_expr(&arg, sstr);
+    write_expr(tmp, sstr);
     repr.push_back(sstr.str());
 }
 
-void ToListVisitor::visit(IndexParameterTerm& arg)
+void visit_IndexParameterTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<IndexParameterTerm>(expr);
     std::stringstream sstr;
-    write_expr(&arg, sstr);
+    write_expr(tmp, sstr);
     repr.push_back(sstr.str());
 }
 
-void ToListVisitor::visit(VariableTerm& arg)
+void visit_VariableTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<VariableTerm>(expr);
     std::stringstream sstr;
-    write_expr(&arg, sstr);
+    write_expr(tmp, sstr);
     repr.push_back(sstr.str());
 }
 
 #if __cpp_lib_variant
-void ToListVisitor::visit(ParameterRefTerm& arg)
+void visit_ParameterRefTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<ParameterRefTerm>(expr);
     std::stringstream sstr;
-    write_expr(&arg, sstr);
+    write_expr(tmp, sstr);
     repr.push_back(sstr.str());
 }
 
-void ToListVisitor::visit(VariableRefTerm& arg)
+void visit_VariableRefTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<VariableRefTerm>(expr);
     std::stringstream sstr;
-    write_expr(&arg, sstr);
+    write_expr(tmp, sstr);
     repr.push_back(sstr.str());
 }
 #endif
 
-void ToListVisitor::visit(MonomialTerm& arg)
+void visit_MonomialTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<MonomialTerm>(expr);
     repr.push_back("[");
     repr.push_back("*");
     {
         std::stringstream sstr;
-        sstr << arg.coef;
+        sstr << tmp->coef;
         repr.push_back(sstr.str());
     }
-    if (arg.var->name.size() == 0) {
+    if (tmp->var->name.size() == 0) {
         // WEH - It's hard to test this logic, since the variable index is dynamically generated
         // GCOVR_EXCL_START
         std::stringstream sstr;
-        sstr << "x" << arg.var->index;
+        sstr << "x" << tmp->var->index;
         repr.push_back(sstr.str());
         // GCOVR_EXCL_STOP
     }
     else {
-        repr.push_back(arg.var->name);
+        repr.push_back(tmp->var->name);
     }
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(InequalityTerm& arg)
+void visit_InequalityTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<InequalityTerm>(expr);
     repr.push_back("[");
-    if (arg.strict)
+    if (tmp->strict)
         repr.push_back("<");
     else
         repr.push_back("<=");
-    if (arg.lower)
-        arg.lower->accept(*this);
+    if (tmp->lower)
+        visit_expression(tmp->lower, repr);
     else
         repr.push_back("-Inf");
-    arg.body->accept(*this);
-    if (arg.upper)
-        arg.upper->accept(*this);
+    visit_expression(tmp->body, repr);
+    if (tmp->upper)
+        visit_expression(tmp->upper, repr);
     else
         repr.push_back("Inf");
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(EqualityTerm& arg)
+void visit_EqualityTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<EqualityTerm>(expr);
     repr.push_back("[");
     repr.push_back("==");
-    arg.body->accept(*this);
-    arg.lower->accept(*this);
+    visit_expression(tmp->body, repr);
+    visit_expression(tmp->lower, repr);
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(ObjectiveTerm& arg)
+void visit_ObjectiveTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<ObjectiveTerm>(expr);
     repr.push_back("[");
-    if (arg.sense)
+    if (tmp->sense)
         repr.push_back("min");
     else
         repr.push_back("max");
-    arg.body->accept(*this);
+    visit_expression(tmp->body, repr);
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(SubExpressionTerm& arg)
+void visit_SubExpressionTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<SubExpressionTerm>(expr);
     repr.push_back("[");
     repr.push_back("_");
-    arg.body->accept(*this);
+    visit_expression(tmp->body, repr);
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(NegateTerm& arg)
+void visit_DefinedValueTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<DefinedValueTerm>(expr);
+    std::stringstream sstr;
+    sstr << "V" << tmp->index;
+    repr.push_back(sstr.str());
+}
+
+void visit_NegateTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
+{
+    auto tmp = safe_pointer_cast<NegateTerm>(expr);
     repr.push_back("[");
     repr.push_back("-");
-    arg.body->accept(*this);
+    visit_expression(tmp->body, repr);
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(PlusTerm& arg)
+void visit_PlusTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<PlusTerm>(expr);
     repr.push_back("[");
     repr.push_back("+");
-    std::vector<expr_pointer_t>& vec = *(arg.data);
-    for (size_t i = 0; i < arg.num_expressions(); i++) vec[i]->accept(*this);
+    std::vector<expr_pointer_t>& vec = *(tmp->data);
+    for (size_t i = 0; i < tmp->num_expressions(); i++) visit_expression(vec[i], repr);
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(TimesTerm& arg)
+void visit_TimesTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<TimesTerm>(expr);
     repr.push_back("[");
     repr.push_back("*");
-    arg.lhs->accept(*this);
-    arg.rhs->accept(*this);
+    visit_expression(tmp->lhs, repr);
+    visit_expression(tmp->rhs, repr);
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(DivideTerm& arg)
+void visit_DivideTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<DivideTerm>(expr);
     repr.push_back("[");
     repr.push_back("/");
-    arg.lhs->accept(*this);
-    arg.rhs->accept(*this);
+    visit_expression(tmp->lhs, repr);
+    visit_expression(tmp->rhs, repr);
     repr.push_back("]");
 }
 
-#define ToListVisitor_FN(FN, TERM)       \
-    void ToListVisitor::visit(TERM& arg) \
-    {                                    \
-        repr.push_back("[");             \
-        repr.push_back(#FN);             \
-        arg.body->accept(*this);         \
-        repr.push_back("]");             \
+#define ToListVisitor_FN(FN, TERM)                                              \
+    void visit_##TERM(const expr_pointer_t& expr, std::list<std::string>& repr) \
+    {                                                                           \
+        auto tmp = safe_pointer_cast<TERM>(expr);                               \
+        repr.push_back("[");                                                    \
+        repr.push_back(#FN);                                                    \
+        visit_expression(tmp->body, repr);                                      \
+        repr.push_back("]");                                                    \
     }
 
 // clang-format off
@@ -242,39 +218,107 @@ ToListVisitor_FN(asinh, ASinhTerm)
 ToListVisitor_FN(acosh, ACoshTerm)
 ToListVisitor_FN(atanh, ATanhTerm)
     // clang-format on
+    //
 
-    void ToListVisitor::visit(PowTerm& arg)
+    void visit_PowTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<PowTerm>(expr);
     repr.push_back("[");
     repr.push_back("pow");
-    arg.lhs->accept(*this);
-    arg.rhs->accept(*this);
+    visit_expression(tmp->lhs, repr);
+    visit_expression(tmp->rhs, repr);
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(SumExpressionTerm&)
+void visit_SumExpressionTerm(const expr_pointer_t&, std::list<std::string>& repr)
 {
+    // auto tmp = safe_pointer_cast<SumExpressionTerm>(expr);
     repr.push_back("[");
     repr.push_back("Sum");
     repr.push_back("]");
 }
 
-void ToListVisitor::visit(IfThenElseTerm& arg)
+void visit_EmptyConstraintTerm(const expr_pointer_t&, std::list<std::string>&) {}
+
+void visit_IfThenElseTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
+    auto tmp = safe_pointer_cast<IfThenElseTerm>(expr);
     repr.push_back("[");
     repr.push_back("If");
-    arg.cond_expr->accept(*this);
-    arg.then_expr->accept(*this);
-    arg.else_expr->accept(*this);
+    visit_expression(tmp->cond_expr, repr);
+    visit_expression(tmp->then_expr, repr);
+    visit_expression(tmp->else_expr, repr);
     repr.push_back("]");
+}
+
+#define VISIT_CASE(TERM) \
+    case TERM##_id:      \
+        return visit_##TERM(expr, repr);
+
+void visit_expression(const expr_pointer_t& expr, std::list<std::string>& repr)
+{
+    switch (expr->id()) {
+        VISIT_CASE(ConstantTerm);
+        VISIT_CASE(ParameterTerm);
+        VISIT_CASE(IndexParameterTerm);
+        VISIT_CASE(VariableTerm);
+#if __cpp_lib_variant
+        VISIT_CASE(VariableRefTerm);
+        VISIT_CASE(ParameterRefTerm);
+#endif
+        VISIT_CASE(MonomialTerm);
+        VISIT_CASE(InequalityTerm);
+        VISIT_CASE(EqualityTerm);
+        VISIT_CASE(ObjectiveTerm);
+        VISIT_CASE(SubExpressionTerm);
+        VISIT_CASE(DefinedValueTerm);
+        VISIT_CASE(NegateTerm);
+        VISIT_CASE(PlusTerm);
+        VISIT_CASE(TimesTerm);
+        VISIT_CASE(DivideTerm);
+        VISIT_CASE(AbsTerm);
+        VISIT_CASE(CeilTerm);
+        VISIT_CASE(FloorTerm);
+        VISIT_CASE(ExpTerm);
+        VISIT_CASE(LogTerm);
+        VISIT_CASE(Log10Term);
+        VISIT_CASE(SqrtTerm);
+        VISIT_CASE(SinTerm);
+        VISIT_CASE(CosTerm);
+        VISIT_CASE(TanTerm);
+        VISIT_CASE(SinhTerm);
+        VISIT_CASE(CoshTerm);
+        VISIT_CASE(TanhTerm);
+        VISIT_CASE(ASinTerm);
+        VISIT_CASE(ACosTerm);
+        VISIT_CASE(ATanTerm);
+        VISIT_CASE(ASinhTerm);
+        VISIT_CASE(ACoshTerm);
+        VISIT_CASE(ATanhTerm);
+        VISIT_CASE(PowTerm);
+        VISIT_CASE(SumExpressionTerm);
+        VISIT_CASE(EmptyConstraintTerm);
+        VISIT_CASE(IfThenElseTerm);
+
+        // GCOVR_EXCL_START
+        default:
+            throw std::runtime_error(
+                "Error in expr_to_list visitor!  Visiting unexpected expression term "
+                + std::to_string(expr->id()));
+            // GCOVR_EXCL_STOP
+    };
 }
 
 }  // namespace
 
 void expr_to_list(BaseExpressionTerm* expr, std::list<std::string>& repr)
 {
-    ToListVisitor visitor(repr);
-    expr->accept(visitor);
+    visit_expression(std::shared_ptr<BaseExpressionTerm>(expr, [](BaseExpressionTerm*) {}), repr);
+}
+
+void expr_to_list(const expr_pointer_t& expr, std::list<std::string>& repr)
+{
+    visit_expression(expr, repr);
 }
 
 }  // namespace coek

--- a/lib/coek/coek/ast/visitor_write_expr.cpp
+++ b/lib/coek/coek/ast/visitor_write_expr.cpp
@@ -7,85 +7,41 @@
 #if __cpp_lib_variant
 #    include "compact_terms.hpp"
 #endif
+#include "coek/util/cast_utils.hpp"
 
 namespace coek {
 
 namespace {
 
-class WriteExprVisitor : public Visitor {
-   public:
-    std::ostream& ostr;
+void visit_expression(const expr_pointer_t& expr, std::ostream& data);
 
-   public:
-    WriteExprVisitor(std::ostream& _ostr) : ostr(_ostr) {}
-
-    void visit(ConstantTerm& arg);
-    void visit(ParameterTerm& arg);
-    void visit(IndexParameterTerm& arg);
-    void visit(VariableTerm& arg);
-#if __cpp_lib_variant
-    void visit(ParameterRefTerm& arg);
-    void visit(VariableRefTerm& arg);
-#endif
-    void visit(MonomialTerm& arg);
-    void visit(InequalityTerm& arg);
-    void visit(EqualityTerm& arg);
-    void visit(ObjectiveTerm& arg);
-    void visit(SubExpressionTerm& arg);
-    void visit(NegateTerm& arg);
-    void visit(PlusTerm& arg);
-    void visit(TimesTerm& arg);
-    void visit(DivideTerm& arg);
-    void visit(AbsTerm& arg);
-    void visit(CeilTerm& arg);
-    void visit(FloorTerm& arg);
-    void visit(ExpTerm& arg);
-    void visit(LogTerm& arg);
-    void visit(Log10Term& arg);
-    void visit(SqrtTerm& arg);
-    void visit(SinTerm& arg);
-    void visit(CosTerm& arg);
-    void visit(TanTerm& arg);
-    void visit(SinhTerm& arg);
-    void visit(CoshTerm& arg);
-    void visit(TanhTerm& arg);
-    void visit(ASinTerm& arg);
-    void visit(ACosTerm& arg);
-    void visit(ATanTerm& arg);
-    void visit(ASinhTerm& arg);
-    void visit(ACoshTerm& arg);
-    void visit(ATanhTerm& arg);
-    void visit(PowTerm& arg);
-    void visit(SumExpressionTerm& arg);
-    void visit(EmptyConstraintTerm& arg);
-    void visit(IfThenElseTerm& arg);
-};
-
-void WriteExprVisitor::visit(ConstantTerm& arg) { ostr << arg.value; }
-
-void WriteExprVisitor::visit(ParameterTerm& arg)
+void visit_ConstantTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
-#if 0
-    // TODO - consider this format for param outputs
-    
-    if (arg.name.size() > 0)
-        ostr << arg.name;
-    ostr << "{" << std::to_string(arg.eval()) << "}";
-#else
-    if (arg.name.size() > 0)
-        ostr << arg.name;
-    else
-        ostr << std::to_string(arg.eval());
-#endif
+    auto tmp = safe_pointer_cast<ConstantTerm>(expr);
+    ostr << tmp->value;
 }
 
-void WriteExprVisitor::visit(IndexParameterTerm& arg) { ostr << arg.name; }
-
-void WriteExprVisitor::visit(VariableTerm& arg)
+void visit_ParameterTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
-    auto name = arg.get_name();
+    auto tmp = safe_pointer_cast<ParameterTerm>(expr);
+    if (tmp->name.size() > 0)
+        ostr << tmp->name;
+    else
+        ostr << std::to_string(tmp->eval());
+}
+
+void visit_IndexParameterTerm(const expr_pointer_t& expr, std::ostream& ostr)
+{
+    auto tmp = safe_pointer_cast<IndexParameterTerm>(expr);
+    ostr << tmp->name;
+}
+
+void visit_VariableTerm(const expr_pointer_t& expr, std::ostream& ostr)
+{
+    auto tmp = safe_pointer_cast<VariableTerm>(expr);
+    auto name = tmp->get_name();
     if (name.size() == 0) {
-        ostr << "x" << arg.index;
+        ostr << "x" << tmp->index;
     }
     else {
         ostr << name;
@@ -93,11 +49,12 @@ void WriteExprVisitor::visit(VariableTerm& arg)
 }
 
 #if __cpp_lib_variant
-void WriteExprVisitor::visit(ParameterRefTerm& arg)
+void visit_ParameterRefTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
+    auto tmp = safe_pointer_cast<ParameterRefTerm>(expr);
     bool first = true;
-    ostr << arg.name << "[";
-    for (auto& val : arg.indices) {
+    ostr << tmp->name << "[";
+    for (auto& val : tmp->indices) {
         if (first)
             first = false;
         else
@@ -106,17 +63,18 @@ void WriteExprVisitor::visit(ParameterRefTerm& arg)
             ostr << *ival;
         }
         else if (auto eval = std::get_if<expr_pointer_t>(&val)) {
-            (*eval)->accept(*this);
+            visit_expression(*eval, ostr);
         }
     }
     ostr << "]";
 }
 
-void WriteExprVisitor::visit(VariableRefTerm& arg)
+void visit_VariableRefTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
+    auto tmp = safe_pointer_cast<VariableRefTerm>(expr);
     bool first = true;
-    ostr << arg.name << "[";
-    for (auto& val : arg.indices) {
+    ostr << tmp->name << "[";
+    for (auto& val : tmp->indices) {
         if (first)
             first = false;
         else
@@ -125,105 +83,118 @@ void WriteExprVisitor::visit(VariableRefTerm& arg)
             ostr << *ival;
         }
         else if (auto eval = std::get_if<expr_pointer_t>(&val)) {
-            (*eval)->accept(*this);
+            visit_expression(*eval, ostr);
         }
     }
     ostr << "]";
 }
 #endif
 
-void WriteExprVisitor::visit(MonomialTerm& arg)
+void visit_MonomialTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
-    if (!(arg.coef == 1.0)) ostr << arg.coef << "*";
-    arg.var->accept(*this);
+    auto tmp = safe_pointer_cast<MonomialTerm>(expr);
+    if (!(tmp->coef == 1.0)) ostr << tmp->coef << "*";
+    visit_expression(tmp->var, ostr);
 }
 
-void WriteExprVisitor::visit(InequalityTerm& arg)
+void visit_InequalityTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
-    if (arg.lower) {
-        arg.lower->accept(*this);
-        if (arg.strict)
+    auto tmp = safe_pointer_cast<InequalityTerm>(expr);
+    if (tmp->lower) {
+        visit_expression(tmp->lower, ostr);
+        if (tmp->strict)
             ostr << " < ";
         else
             ostr << " <= ";
     }
-    arg.body->accept(*this);
-    if (arg.upper) {
-        if (arg.strict)
+    visit_expression(tmp->body, ostr);
+    if (tmp->upper) {
+        if (tmp->strict)
             ostr << " < ";
         else
             ostr << " <= ";
-        arg.upper->accept(*this);
+        visit_expression(tmp->upper, ostr);
     }
 }
 
-void WriteExprVisitor::visit(EqualityTerm& arg)
+void visit_EqualityTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
-    arg.body->accept(*this);
+    auto tmp = safe_pointer_cast<EqualityTerm>(expr);
+    visit_expression(tmp->body, ostr);
     ostr << " == ";
-    arg.lower->accept(*this);
+    visit_expression(tmp->lower, ostr);
 }
 
-void WriteExprVisitor::visit(ObjectiveTerm& arg)
+void visit_ObjectiveTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
-    if (arg.sense)
+    auto tmp = safe_pointer_cast<ObjectiveTerm>(expr);
+    if (tmp->sense)
         ostr << "min( ";
     else
         ostr << "max( ";
-    arg.body->accept(*this);
+    visit_expression(tmp->body, ostr);
     ostr << " )";
 }
 
-void WriteExprVisitor::visit(SubExpressionTerm& arg) { arg.body->accept(*this); }
-
-void WriteExprVisitor::visit(NegateTerm& arg)
+void visit_SubExpressionTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
+    auto tmp = safe_pointer_cast<SubExpressionTerm>(expr);
+    visit_expression(tmp->body, ostr);
+}
+
+void visit_NegateTerm(const expr_pointer_t& expr, std::ostream& ostr)
+{
+    auto tmp = safe_pointer_cast<NegateTerm>(expr);
     ostr << "- (";
-    arg.body->accept(*this);
+    visit_expression(tmp->body, ostr);
     ostr << ")";
 }
 
-void WriteExprVisitor::visit(PlusTerm& arg)
+void visit_PlusTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
-    std::vector<expr_pointer_t>& vec = *(arg.data);
+    auto tmp = safe_pointer_cast<PlusTerm>(expr);
+    std::vector<expr_pointer_t>& vec = *(tmp->data);
     // GCOVR_EXCL_START
     if (vec.size() == 0) {
         ostr << "NULL-SUM";
         return;
     }
     // GCOVR_EXCL_STOP
-    vec[0]->accept(*this);
+    visit_expression(vec[0], ostr);
 
-    for (size_t i = 1; i < arg.num_expressions(); i++) {
+    for (size_t i = 1; i < tmp->num_expressions(); i++) {
         ostr << " + ";
-        vec[i]->accept(*this);
+        visit_expression(vec[i], ostr);
     }
 }
 
-void WriteExprVisitor::visit(TimesTerm& arg)
+void visit_TimesTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
+    auto tmp = safe_pointer_cast<TimesTerm>(expr);
     ostr << "(";
-    arg.lhs->accept(*this);
+    visit_expression(tmp->lhs, ostr);
     ostr << ")*(";
-    arg.rhs->accept(*this);
+    visit_expression(tmp->rhs, ostr);
     ostr << ")";
 }
 
-void WriteExprVisitor::visit(DivideTerm& arg)
+void visit_DivideTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
+    auto tmp = safe_pointer_cast<DivideTerm>(expr);
     ostr << "(";
-    arg.lhs->accept(*this);
+    visit_expression(tmp->lhs, ostr);
     ostr << ")/(";
-    arg.rhs->accept(*this);
+    visit_expression(tmp->rhs, ostr);
     ostr << ")";
 }
 
-#define WriteExprVisitor_FN(FN, TERM)       \
-    void WriteExprVisitor::visit(TERM& arg) \
-    {                                       \
-        ostr << #FN << "(";                 \
-        arg.body->accept(*this);            \
-        ostr << ")";                        \
+#define WriteExprVisitor_FN(FN, TERM)                                 \
+    void visit_##TERM(const expr_pointer_t& expr, std::ostream& ostr) \
+    {                                                                 \
+        auto tmp = safe_pointer_cast<TERM>(expr);                     \
+        ostr << #FN << "(";                                           \
+        visit_expression(tmp->body, ostr);                            \
+        ostr << ")";                                                  \
     }
 
 // clang-format off
@@ -250,28 +221,91 @@ WriteExprVisitor_FN(atanh, ATanhTerm)
 
     // clang-format on
 
-    void WriteExprVisitor::visit(PowTerm& arg)
+    void visit_PowTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
+    auto tmp = safe_pointer_cast<PowTerm>(expr);
     ostr << "pow(";
-    arg.lhs->accept(*this);
+    visit_expression(tmp->lhs, ostr);
     ostr << ", ";
-    arg.rhs->accept(*this);
+    visit_expression(tmp->rhs, ostr);
     ostr << ")";
 }
 
-void WriteExprVisitor::visit(SumExpressionTerm&) { ostr << "Sum()"; }
+void visit_SumExpressionTerm(const expr_pointer_t&, std::ostream& ostr) { ostr << "Sum()"; }
 
-void WriteExprVisitor::visit(EmptyConstraintTerm&) { ostr << "EmptyConstraint()"; }
-
-void WriteExprVisitor::visit(IfThenElseTerm& arg)
+void visit_EmptyConstraintTerm(const expr_pointer_t&, std::ostream& ostr)
 {
+    ostr << "EmptyConstraint()";
+}
+
+void visit_IfThenElseTerm(const expr_pointer_t& expr, std::ostream& ostr)
+{
+    auto tmp = safe_pointer_cast<IfThenElseTerm>(expr);
     ostr << "if_else(";
-    arg.cond_expr->accept(*this);
+    visit_expression(tmp->cond_expr, ostr);
     ostr << ", ";
-    arg.then_expr->accept(*this);
+    visit_expression(tmp->then_expr, ostr);
     ostr << ", ";
-    arg.else_expr->accept(*this);
+    visit_expression(tmp->else_expr, ostr);
     ostr << ")";
+}
+
+#define VISIT_CASE(TERM) \
+    case TERM##_id:      \
+        return visit_##TERM(expr, ostr);
+
+void visit_expression(const expr_pointer_t& expr, std::ostream& ostr)
+{
+    switch (expr->id()) {
+        VISIT_CASE(ConstantTerm);
+        VISIT_CASE(ParameterTerm);
+        VISIT_CASE(IndexParameterTerm);
+        VISIT_CASE(VariableTerm);
+#if __cpp_lib_variant
+        VISIT_CASE(ParameterRefTerm);
+        VISIT_CASE(VariableRefTerm);
+#endif
+
+        VISIT_CASE(MonomialTerm);
+        VISIT_CASE(InequalityTerm);
+        VISIT_CASE(EqualityTerm);
+        VISIT_CASE(ObjectiveTerm);
+        VISIT_CASE(SubExpressionTerm);
+        VISIT_CASE(NegateTerm);
+        VISIT_CASE(PlusTerm);
+        VISIT_CASE(TimesTerm);
+        VISIT_CASE(DivideTerm);
+        VISIT_CASE(AbsTerm);
+        VISIT_CASE(CeilTerm);
+        VISIT_CASE(FloorTerm);
+        VISIT_CASE(ExpTerm);
+        VISIT_CASE(LogTerm);
+        VISIT_CASE(Log10Term);
+        VISIT_CASE(SqrtTerm);
+        VISIT_CASE(SinTerm);
+        VISIT_CASE(CosTerm);
+        VISIT_CASE(TanTerm);
+        VISIT_CASE(SinhTerm);
+        VISIT_CASE(CoshTerm);
+        VISIT_CASE(TanhTerm);
+        VISIT_CASE(ASinTerm);
+        VISIT_CASE(ACosTerm);
+        VISIT_CASE(ATanTerm);
+        VISIT_CASE(ASinhTerm);
+        VISIT_CASE(ACoshTerm);
+        VISIT_CASE(ATanhTerm);
+        VISIT_CASE(PowTerm);
+        VISIT_CASE(SumExpressionTerm);
+        VISIT_CASE(EmptyConstraintTerm);
+        VISIT_CASE(IfThenElseTerm);
+
+        // GCOVR_EXCL_START
+        default:
+            throw std::runtime_error(
+                "Error in write_expr visitor!  Visiting unexpected expression term "
+                + std::to_string(expr->id()));
+            // GCOVR_EXCL_STOP
+    };
 }
 
 }  // namespace
@@ -287,8 +321,9 @@ void write_expr(BaseExpressionTerm* expr, std::ostream& ostr)
         return;
     }
     // GCOVR_EXCL_STOP
-    WriteExprVisitor visitor(ostr);
-    expr->accept(visitor);
+    visit_expression(std::shared_ptr<BaseExpressionTerm>(expr, [](BaseExpressionTerm*) {}), ostr);
 }
+
+void write_expr(const expr_pointer_t& expr, std::ostream& ostr) { visit_expression(expr, ostr); }
 
 }  // namespace coek

--- a/lib/coek/coek/solvers/gurobi/gurobi.cpp
+++ b/lib/coek/coek/solvers/gurobi/gurobi.cpp
@@ -185,8 +185,7 @@ int GurobiSolver::solve(Model& model)
     }
 
     // All options are converted to strings for Gurobi
-    for (auto& it : string_options())
-        gmodel->set(it.first, it.second);
+    for (auto& it : string_options()) gmodel->set(it.first, it.second);
 
     try {
         gmodel->optimize();
@@ -307,8 +306,7 @@ int GurobiSolver::solve(CompactModel& compact_model)
 
     std::cout << "OPTIMIZING GUROBI MODEL" << std::endl << std::flush;
     // All options are converted to strings for Gurobi
-    for (auto& it : string_options)
-        gmodel->set(it.first, it.second);
+    for (auto& it : string_options) gmodel->set(it.first, it.second);
     try {
         gmodel->optimize();
 
@@ -421,8 +419,7 @@ int GurobiSolver::resolve()
         }
 
         // All options are converted to strings for Gurobi
-        for (auto& option : string_options())
-            gmodel->set(option.first, option.second);
+        for (auto& option : string_options()) gmodel->set(option.first, option.second);
 
         try {
             gmodel->optimize();

--- a/lib/coek/coek/util/option_cache.cpp
+++ b/lib/coek/coek/util/option_cache.cpp
@@ -29,20 +29,14 @@ const std::map<std::string, std::string>& OptionCache::string_options() const
     return options->string_options;
 }
 
-std::map<std::string, int>& OptionCache::integer_options()
-{
-    return options->integer_options;
-}
+std::map<std::string, int>& OptionCache::integer_options() { return options->integer_options; }
 
 const std::map<std::string, int>& OptionCache::integer_options() const
 {
     return options->integer_options;
 }
 
-std::map<std::string, double>& OptionCache::double_options()
-{
-    return options->double_options;
-}
+std::map<std::string, double>& OptionCache::double_options() { return options->double_options; }
 
 const std::map<std::string, double>& OptionCache::double_options() const
 {


### PR DESCRIPTION
This change simplifies the AST classes by removing Visitor.  This class was a single point of integration for all AST classes, which proved restrictive.