### PR TITLE
Various changes

### DIFF
--- a/lib/coek/coek/api/constraint.cpp
+++ b/lib/coek/coek/api/constraint.cpp
@@ -10,7 +10,7 @@
 namespace coek {
 
 #ifdef COEK_WITH_COMPACT_MODEL
-std::shared_ptr<ConstraintTerm> convert_con_template(std::shared_ptr<ConstraintTerm> con);
+std::shared_ptr<ConstraintTerm> convert_con_template(const std::shared_ptr<ConstraintTerm>& con);
 #endif
 
 //

--- a/lib/coek/coek/api/expression.cpp
+++ b/lib/coek/coek/api/expression.cpp
@@ -9,7 +9,7 @@
 namespace coek {
 
 #ifdef COEK_WITH_COMPACT_MODEL
-expr_pointer_t convert_expr_template(expr_pointer_t expr);
+expr_pointer_t convert_expr_template(const expr_pointer_t& expr);
 #endif
 
 //

--- a/lib/coek/coek/api/parameter_array.cpp
+++ b/lib/coek/coek/api/parameter_array.cpp
@@ -107,7 +107,7 @@ Parameter ParameterArray::index(const IndexVector& args)
     // We know that the args[i] values are nonnegative b.c. we have asserted that while
     // processing these arguments
     size_t ndx = static_cast<size_t>(args[0]);
-    for (size_t i = 1; i < args.size(); i++) ndx = ndx * shape[i] + args[i];
+    for (size_t i = 1; i < args.size(); i++) ndx = ndx * shape[i] + static_cast<size_t>(args[i]);
 
     if (ndx > size()) {
         // TODO - Can't we do better than this check?  Do we check if each index is in the correct

--- a/lib/coek/coek/api/variable_assoc_array.cpp
+++ b/lib/coek/coek/api/variable_assoc_array.cpp
@@ -181,8 +181,7 @@ expr_pointer_t get_concrete_var(VariableRefTerm& varref)
     VariableAssocArray* var = static_cast<VariableAssocArray*>(varref.var);
 
     std::vector<int> index;
-    for (auto it = varref.indices.begin(); it != varref.indices.end(); ++it) {
-        refarg_types& reftmp = *it;
+    for (auto& reftmp : varref.indices) {
         if (auto ival = std::get_if<int>(&reftmp))
             index.push_back(*ival);
         else {

--- a/lib/coek/coek/ast/visitor_eval.cpp
+++ b/lib/coek/coek/ast/visitor_eval.cpp
@@ -5,7 +5,7 @@
 #include "visitor.hpp"
 #include "visitor_fns.hpp"
 #include "../util/cast_utils.hpp"
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 #    include "compact_terms.hpp"
 #endif
 

--- a/lib/coek/coek/ast/visitor_mutable_values.cpp
+++ b/lib/coek/coek/ast/visitor_mutable_values.cpp
@@ -5,7 +5,7 @@
 #include "visitor.hpp"
 #include "visitor_fns.hpp"
 #include "../util/cast_utils.hpp"
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 #    include "compact_terms.hpp"
 #endif
 
@@ -69,7 +69,7 @@ void visit_VariableTerm(const expr_pointer_t& expr, MutableValuesData& data)
     if (tmp->fixed) data.fixed_vars.insert(tmp);
 }
 
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 void visit_ParameterRefTerm(const expr_pointer_t& /*expr*/, MutableValuesData& /*data*/) {}
 
 void visit_VariableRefTerm(const expr_pointer_t& /*expr*/, MutableValuesData& /*data*/) {}

--- a/lib/coek/coek/ast/visitor_simplify.cpp
+++ b/lib/coek/coek/ast/visitor_simplify.cpp
@@ -6,11 +6,9 @@
 #include "visitor.hpp"
 #include "visitor_fns.hpp"
 #include "../util/cast_utils.hpp"
-/*
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 #    include "compact_terms.hpp"
 #endif
-*/
 
 namespace coek {
 
@@ -384,6 +382,12 @@ void visit_PowTerm(const expr_pointer_t& expr, VisitorData& data)
     }
 }
 
+void visit_SumExpressionTerm(const expr_pointer_t& expr, VisitorData& data)
+{
+    data.last_expr = expr;
+    data.is_value = false;
+}
+
 #define VISIT_CASE(TERM) \
     case TERM##_id:      \
         return visit_##TERM(expr, data);
@@ -429,6 +433,7 @@ void visit_expression(const expr_pointer_t& expr, VisitorData& data)
         VISIT_CASE(ACoshTerm);
         VISIT_CASE(ATanhTerm);
         VISIT_CASE(PowTerm);
+        VISIT_CASE(SumExpressionTerm);
 
         // GCOVR_EXCL_START
         default:

--- a/lib/coek/coek/ast/visitor_symdiff.cpp
+++ b/lib/coek/coek/ast/visitor_symdiff.cpp
@@ -8,7 +8,7 @@
 #include "visitor.hpp"
 #include "visitor_fns.hpp"
 #include "../util/cast_utils.hpp"
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 #    include "compact_terms.hpp"
 #endif
 
@@ -57,7 +57,7 @@ void visit_VariableTerm(const expr_pointer_t& /*expr*/, PartialData& data)
     data.partial = ONECONST;
 }
 
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 void visit_ParameterRefTerm(const expr_pointer_t& /*expr*/, PartialData& data)
 {
     data.partial = ZEROCONST;

--- a/lib/coek/coek/ast/visitor_to_QuadraticExpr.cpp
+++ b/lib/coek/coek/ast/visitor_to_QuadraticExpr.cpp
@@ -60,9 +60,6 @@ void visit(std::shared_ptr<IndexParameterTerm>& /*expr*/, QuadraticExpr& /*repn*
 
 void visit(std::shared_ptr<VariableTerm>& expr, QuadraticExpr& repn, double multiplier)
 {
-    // if (! expr.index)
-    //     throw std::runtime_error("Unexpected variable not owned by a model.");
-
     if (expr->fixed) {
         repn.constval += multiplier * expr->value->eval();
     }
@@ -82,9 +79,6 @@ void visit(std::shared_ptr<VariableRefTerm>& /*expr*/, QuadraticExpr& /*repn*/,
 
 void visit(std::shared_ptr<MonomialTerm>& expr, QuadraticExpr& repn, double multiplier)
 {
-    // if (! expr.var->index)
-    //     throw std::runtime_error("Unexpected variable not owned by a model.");
-
     if (expr->var->fixed) {
         repn.constval += multiplier * expr->coef * expr->var->value->eval();
     }

--- a/lib/coek/coek/ast/visitor_to_list.cpp
+++ b/lib/coek/coek/ast/visitor_to_list.cpp
@@ -6,7 +6,7 @@
 #include "value_terms.hpp"
 #include "visitor.hpp"
 #include "visitor_fns.hpp"
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 #    include "compact_terms.hpp"
 #endif
 #include "coek/util/cast_utils.hpp"
@@ -47,7 +47,7 @@ void visit_VariableTerm(const expr_pointer_t& expr, std::list<std::string>& repr
     repr.push_back(sstr.str());
 }
 
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 void visit_ParameterRefTerm(const expr_pointer_t& expr, std::list<std::string>& repr)
 {
     auto tmp = safe_pointer_cast<ParameterRefTerm>(expr);

--- a/lib/coek/coek/ast/visitor_variables.cpp
+++ b/lib/coek/coek/ast/visitor_variables.cpp
@@ -5,7 +5,7 @@
 #include "visitor.hpp"
 #include "visitor_fns.hpp"
 #include "../util/cast_utils.hpp"
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 #    include "compact_terms.hpp"
 #endif
 

--- a/lib/coek/coek/ast/visitor_write_expr.cpp
+++ b/lib/coek/coek/ast/visitor_write_expr.cpp
@@ -4,7 +4,7 @@
 #include "value_terms.hpp"
 #include "visitor.hpp"
 #include "visitor_fns.hpp"
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 #    include "compact_terms.hpp"
 #endif
 #include "coek/util/cast_utils.hpp"
@@ -48,7 +48,7 @@ void visit_VariableTerm(const expr_pointer_t& expr, std::ostream& ostr)
     }
 }
 
-#if __cpp_lib_variant
+#ifdef COEK_WITH_COMPACT_MODEL
 void visit_ParameterRefTerm(const expr_pointer_t& expr, std::ostream& ostr)
 {
     auto tmp = safe_pointer_cast<ParameterRefTerm>(expr);

--- a/lib/coek/coek/compact/coek_exprterm.hpp
+++ b/lib/coek/coek/compact/coek_exprterm.hpp
@@ -16,7 +16,6 @@ class SumExpressionTerm : public BaseExpressionTerm {
 
     bool is_expression() const { return false; }
 
-    void accept(Visitor& v) { v.visit(*this); }
     term_id id() { return SumExpressionTerm_id; }
 };
 

--- a/lib/coek/coek/compact/constraint_sequence.cpp
+++ b/lib/coek/coek/compact/constraint_sequence.cpp
@@ -4,10 +4,9 @@
 #include "coek/api/expression.hpp"
 #include "coek_sets.hpp"
 #include "sequence_context.hpp"
+#include "visitor_exprtemplate.hpp"
 
 namespace coek {
-
-std::shared_ptr<ConstraintTerm> convert_con_template(std::shared_ptr<ConstraintTerm> expr);
 
 //
 // ConstraintSequenceRepn

--- a/lib/coek/coek/compact/expression_sequence.cpp
+++ b/lib/coek/coek/compact/expression_sequence.cpp
@@ -1,13 +1,13 @@
 #include "expression_sequence.hpp"
 
+#include "coek/util/cast_utils.hpp"
 #include "coek/api/expression.hpp"
 #include "coek/compact/coek_exprterm.hpp"
 #include "coek_sets.hpp"
 #include "sequence_context.hpp"
+#include "visitor_exprtemplate.hpp"
 
 namespace coek {
-
-expr_pointer_t convert_expr_template(expr_pointer_t expr);
 
 //
 // ExpressionSequenceRepn
@@ -175,12 +175,13 @@ const ExpressionSeqIterator ExpressionSequence::end() const
     return ExpressionSeqIterator(repn.get(), true);
 }
 
-namespace visitors {
+namespace convert_expr_visitor {
 
-expr_pointer_t visit(SumExpressionTerm& arg)
+expr_pointer_t visit_SumExpressionTerm(const expr_pointer_t& expr)
 {
-    auto it = arg.seq.begin();
-    if (it == arg.seq.end()) {
+    auto tmp = safe_pointer_cast<SumExpressionTerm>(expr);
+    auto it = tmp->seq.begin();
+    if (it == tmp->seq.end()) {
         return ZEROCONST;
     }
 
@@ -188,7 +189,7 @@ expr_pointer_t visit(SumExpressionTerm& arg)
     {
         Expression e = *it;
         ++it;
-        for (; it != arg.seq.end(); ++it) {
+        for (; it != tmp->seq.end(); ++it) {
             e += *it;
         }
         curr = e.repn;
@@ -196,7 +197,7 @@ expr_pointer_t visit(SumExpressionTerm& arg)
     return curr;
 }
 
-}  // namespace visitors
+}  // namespace convert_expr_visitor
 
 //
 // Sum

--- a/lib/coek/coek/compact/objective_sequence.cpp
+++ b/lib/coek/coek/compact/objective_sequence.cpp
@@ -5,10 +5,9 @@
 #include "coek_sets.hpp"
 #include "sequence_context.hpp"
 #include "objective_sequence.hpp"
+#include "visitor_exprtemplate.hpp"
 
 namespace coek {
-
-expr_pointer_t convert_expr_template(expr_pointer_t expr);
 
 //
 // ObjectiveSequenceRepn

--- a/lib/coek/coek/compact/variable_sequence.cpp
+++ b/lib/coek/coek/compact/variable_sequence.cpp
@@ -4,10 +4,9 @@
 #include "coek/compact/coek_exprterm.hpp"
 #include "coek_sets.hpp"
 #include "sequence_context.hpp"
+#include "visitor_exprtemplate.hpp"
 
 namespace coek {
-
-expr_pointer_t convert_expr_template(expr_pointer_t expr);
 
 //
 // VariableSequenceRepn

--- a/lib/coek/coek/compact/visitor_exprtemplate.cpp
+++ b/lib/coek/coek/compact/visitor_exprtemplate.cpp
@@ -3,6 +3,7 @@
 #include "../ast/compact_terms.hpp"
 #include "../ast/constraint_terms.hpp"
 #include "../ast/expr_terms.hpp"
+#include "../util/cast_utils.hpp"
 #include "coek/api/expression.hpp"
 #include "coek_exprterm.hpp"
 
@@ -11,92 +12,144 @@ namespace coek {
 expr_pointer_t get_concrete_var(VariableRefTerm& varref);
 expr_pointer_t get_concrete_param(ParameterRefTerm& paramref);
 
-namespace visitors {
+namespace convert_expr_visitor {
 
-expr_pointer_t visit_expression(expr_pointer_t expr);
-expr_pointer_t visit(SumExpressionTerm&);
+expr_pointer_t visit_expression(const expr_pointer_t& expr);
+expr_pointer_t visit_SumExpressionTerm(const expr_pointer_t& expr);
 
-expr_pointer_t visit(IndexParameterTerm& arg)
+// ConstantTerm ignored
+
+// ParameterTerm ignored
+
+expr_pointer_t visit_IndexParameterTerm(const expr_pointer_t& expr)
 {
+    auto tmp = safe_pointer_cast<IndexParameterTerm>(expr);
+
     //  TODO - embed this logic in the IndexParameterTerm class
-    if (arg.type == 1)
-        return CREATE_POINTER(ConstantTerm, arg.double_value);
-    else if (arg.type == 2)
-        return CREATE_POINTER(ConstantTerm, arg.int_value);
+    if (tmp->type == 1)
+        return std::make_shared<ConstantTerm>(tmp->double_value);
+    else if (tmp->type == 2)
+        return std::make_shared<ConstantTerm>(tmp->int_value);
     else
         throw std::runtime_error(
             "Unexpected index parameter in an expression being converted, with a non-numeric "
             "value.");
 }
 
-expr_pointer_t visit(VariableRefTerm& arg) { return get_concrete_var(arg); }
-
-expr_pointer_t visit(ParameterRefTerm& arg) { return get_concrete_param(arg); }
-
-expr_pointer_t visit(InequalityTerm& arg)
+expr_pointer_t visit_ParameterRefTerm(const expr_pointer_t& expr)
 {
-    auto lower = arg.lower ? visit_expression(arg.lower) : 0;
-    auto body = visit_expression(arg.body);
-    auto upper = arg.upper ? visit_expression(arg.upper) : 0;
-    return CREATE_POINTER(InequalityTerm, lower, body, upper);
+    auto tmp = safe_pointer_cast<ParameterRefTerm>(expr);
+    return get_concrete_param(*tmp);
 }
 
-expr_pointer_t visit(EqualityTerm& arg)
+expr_pointer_t visit_VariableRefTerm(const expr_pointer_t& expr)
 {
-    auto body = visit_expression(arg.body);
-    auto lower = visit_expression(arg.lower);
-    return CREATE_POINTER(EqualityTerm, body, lower);
+    auto tmp = safe_pointer_cast<VariableRefTerm>(expr);
+    return get_concrete_var(*tmp);
 }
 
-expr_pointer_t visit(ObjectiveTerm& arg)
+expr_pointer_t visit_ObjectiveTerm(const expr_pointer_t& expr)
 {
-    auto body = visit_expression(arg.body);
-    return CREATE_POINTER(ObjectiveTerm, body, arg.sense);
+    auto tmp = safe_pointer_cast<ObjectiveTerm>(expr);
+    auto body = visit_expression(tmp->body);
+    if (body->id() == tmp->id()) return expr;
+    return std::make_shared<ObjectiveTerm>(body, tmp->sense);
 }
 
-expr_pointer_t visit(SubExpressionTerm& arg) { return visit_expression(arg.body); }
-
-expr_pointer_t visit(NegateTerm& arg)
+expr_pointer_t visit_InequalityTerm(const expr_pointer_t& expr)
 {
-    auto curr = visit_expression(arg.body);
-    return CREATE_POINTER(NegateTerm, curr);
+    auto tmp = safe_pointer_cast<InequalityTerm>(expr);
+    auto lower = tmp->lower ? visit_expression(tmp->lower) : tmp->lower;
+    auto body = visit_expression(tmp->body);
+    auto upper = tmp->upper ? visit_expression(tmp->upper) : tmp->upper;
+    if ((not tmp->lower or (lower->id() == tmp->lower->id())) and (body->id() == tmp->body->id())
+        and (not tmp->upper or (upper->id() == tmp->upper->id())))
+        return expr;
+    return std::make_shared<InequalityTerm>(lower, body, upper);
 }
 
-expr_pointer_t visit(PlusTerm& arg)
+expr_pointer_t visit_EqualityTerm(const expr_pointer_t& expr)
 {
-    auto lhs = visit_expression((*(arg.data))[0]);
-    auto curr = visit_expression((*(arg.data))[1]);
-    curr = CREATE_POINTER(PlusTerm, lhs, curr, false);
-    if (arg.n == 2) return curr;
+    auto tmp = safe_pointer_cast<EqualityTerm>(expr);
+    return std::make_shared<EqualityTerm>(visit_expression(tmp->body),
+                                          visit_expression(tmp->lower));
+}
 
-    auto _curr = std::dynamic_pointer_cast<PlusTerm>(curr);
+expr_pointer_t visit_SubExpressionTerm(const expr_pointer_t& expr)
+{
+    auto tmp = safe_pointer_cast<SubExpressionTerm>(expr);
+    return visit_expression(tmp->body);
+}
 
-    for (size_t i = 2; i < arg.num_expressions(); i++) {
-        curr = visit_expression((*(arg.data))[i]);
-        _curr->push_back(curr);
+expr_pointer_t visit_NegateTerm(const expr_pointer_t& expr)
+{
+    auto tmp = safe_pointer_cast<NegateTerm>(expr);
+    auto body = visit_expression(tmp->body);
+    if (body->id() == tmp->body->id()) return expr;
+    return std::make_shared<NegateTerm>(body);
+}
+
+expr_pointer_t visit_PlusTerm(const expr_pointer_t& expr)
+{
+    auto tmp = safe_pointer_cast<PlusTerm>(expr);
+
+    auto data = *(tmp->data);
+    auto lhs = visit_expression(data[0]);
+    auto curr = visit_expression(data[1]);
+    if (tmp->n == 2) {
+        if ((lhs->id() == data[0]->id()) and (curr->id() == data[1]->id())) return expr;
+        return std::make_shared<PlusTerm>(lhs, curr, false);
     }
+
+    auto _curr = std::make_shared<PlusTerm>(lhs, curr, false);
+    bool flag = (lhs->id() == data[0]->id()) and (curr->id() == data[1]->id());
+
+    for (size_t i = 2; i < tmp->num_expressions(); i++) {
+        auto curr = visit_expression(data[i]);
+        _curr->push_back(curr);
+        flag = flag and (curr->id() == data[i]->id());
+    }
+    if (flag) return expr;
     return _curr;
 }
 
-expr_pointer_t visit(TimesTerm& arg)
+expr_pointer_t visit_TimesTerm(const expr_pointer_t& expr)
 {
-    auto lhs = visit_expression(arg.lhs);
-    auto rhs = visit_expression(arg.rhs);
-    return CREATE_POINTER(TimesTerm, lhs, rhs);
+    auto tmp = safe_pointer_cast<TimesTerm>(expr);
+    auto lhs = visit_expression(tmp->lhs);
+    auto rhs = visit_expression(tmp->rhs);
+    if ((lhs->id() == tmp->lhs->id()) and (rhs->id() == tmp->rhs->id())) return expr;
+    return std::make_shared<TimesTerm>(lhs, rhs);
 }
 
-expr_pointer_t visit(DivideTerm& arg)
+expr_pointer_t visit_DivideTerm(const expr_pointer_t& expr)
 {
-    auto lhs = visit_expression(arg.lhs);
-    auto rhs = visit_expression(arg.rhs);
-    return CREATE_POINTER(DivideTerm, lhs, rhs);
+    auto tmp = safe_pointer_cast<DivideTerm>(expr);
+    auto lhs = visit_expression(tmp->lhs);
+    auto rhs = visit_expression(tmp->rhs);
+    if ((lhs->id() == tmp->lhs->id()) and (rhs->id() == tmp->rhs->id())) return expr;
+    return std::make_shared<DivideTerm>(lhs, rhs);
 }
 
-#define UNARY_VISITOR(TERM)                     \
-    expr_pointer_t visit(TERM& arg)             \
-    {                                           \
-        auto curr = visit_expression(arg.body); \
-        return CREATE_POINTER(TERM, curr);      \
+expr_pointer_t visit_IfThenElseTerm(const expr_pointer_t& expr)
+{
+    auto tmp = safe_pointer_cast<IfThenElseTerm>(expr);
+    auto cond_expr = visit_expression(tmp->cond_expr);
+    auto then_expr = visit_expression(tmp->then_expr);
+    auto else_expr = visit_expression(tmp->else_expr);
+    if ((cond_expr->id() == tmp->cond_expr->id()) and (then_expr->id() == tmp->then_expr->id())
+        and (else_expr->id() == tmp->else_expr->id()))
+        return expr;
+    return std::make_shared<IfThenElseTerm>(cond_expr, then_expr, else_expr);
+}
+
+#define UNARY_VISITOR(TERM)                                 \
+    expr_pointer_t visit_##TERM(const expr_pointer_t& expr) \
+    {                                                       \
+        auto tmp = safe_pointer_cast<TERM>(expr);           \
+        auto body = visit_expression(tmp->body);            \
+        if (body->id() == tmp->body->id()) return expr;     \
+        return std::make_shared<TERM>(body);                \
     }
 
 UNARY_VISITOR(AbsTerm)
@@ -119,18 +172,20 @@ UNARY_VISITOR(ASinhTerm)
 UNARY_VISITOR(ACoshTerm)
 UNARY_VISITOR(ATanhTerm)
 
-expr_pointer_t visit(PowTerm& arg)
+expr_pointer_t visit_PowTerm(const expr_pointer_t& expr)
 {
-    auto lhs = visit_expression(arg.lhs);
-    auto rhs = visit_expression(arg.rhs);
-    return CREATE_POINTER(PowTerm, lhs, rhs);
+    auto tmp = safe_pointer_cast<PowTerm>(expr);
+    auto lhs = visit_expression(tmp->lhs);
+    auto rhs = visit_expression(tmp->rhs);
+    if ((lhs->id() == tmp->lhs->id()) and (rhs->id() == tmp->rhs->id())) return expr;
+    return std::make_shared<PowTerm>(lhs, rhs);
 }
 
 #define VISIT_CASE(TERM) \
     case TERM##_id:      \
-        return visit(*std::dynamic_pointer_cast<TERM>(expr));
+        return visit_##TERM(expr);
 
-expr_pointer_t visit_expression(expr_pointer_t expr)
+expr_pointer_t visit_expression(const expr_pointer_t& expr)
 {
     switch (expr->id()) {
         case ConstantTerm_id:
@@ -139,9 +194,15 @@ expr_pointer_t visit_expression(expr_pointer_t expr)
         case MonomialTerm_id:
             return expr;
 
+            // VISIT_CASE(ConstantTerm);
+            // VISIT_CASE(ParameterTerm);
             VISIT_CASE(IndexParameterTerm);
+            // VISIT_CASE(VariableTerm);
+#ifdef COEK_WITH_COMPACT_MODEL
             VISIT_CASE(VariableRefTerm);
             VISIT_CASE(ParameterRefTerm);
+#endif
+            // VISIT_CASE(MonomialTerm);
             VISIT_CASE(InequalityTerm);
             VISIT_CASE(EqualityTerm);
             VISIT_CASE(ObjectiveTerm);
@@ -150,6 +211,7 @@ expr_pointer_t visit_expression(expr_pointer_t expr)
             VISIT_CASE(PlusTerm);
             VISIT_CASE(TimesTerm);
             VISIT_CASE(DivideTerm);
+            VISIT_CASE(IfThenElseTerm);
             VISIT_CASE(AbsTerm);
             VISIT_CASE(CeilTerm);
             VISIT_CASE(FloorTerm);
@@ -171,34 +233,34 @@ expr_pointer_t visit_expression(expr_pointer_t expr)
             VISIT_CASE(ATanhTerm);
             VISIT_CASE(PowTerm);
             VISIT_CASE(SumExpressionTerm);
+
+        // GCOVR_EXCL_START
+        default:
+            throw std::runtime_error(
+                "Error in convert_expr or convert_con visitor!  Visiting unexpected expression "
+                "term "
+                + std::to_string(expr->id()));
+            // GCOVR_EXCL_STOP
     };
 
     return 0;
 }
 
-}  // namespace visitors
+}  // namespace convert_expr_visitor
 
-expr_pointer_t convert_expr_template(expr_pointer_t expr)
+expr_pointer_t convert_expr_template(const expr_pointer_t& expr)
 {
     if (expr == 0) throw std::runtime_error("Unexpected null expression");
 
-    return visitors::visit_expression(expr);
+    return convert_expr_visitor::visit_expression(expr);
 }
 
-std::shared_ptr<ConstraintTerm> convert_con_template(std::shared_ptr<ConstraintTerm> expr)
+std::shared_ptr<ConstraintTerm> convert_con_template(const std::shared_ptr<ConstraintTerm>& expr)
 {
     if (expr == 0) throw std::runtime_error("Unexpected null constraint");
 
-    auto curr = visitors::visit_expression(expr->body);
-    if (expr->is_equality()) {
-        auto lower = expr->lower ? visitors::visit_expression(expr->lower) : 0;
-        return CREATE_POINTER(EqualityTerm, curr, lower);
-    }
-    else {
-        auto lower = expr->lower ? visitors::visit_expression(expr->lower) : 0;
-        auto upper = expr->upper ? visitors::visit_expression(expr->upper) : 0;
-        return CREATE_POINTER(InequalityTerm, lower, curr, upper);
-    }
+    auto ans = convert_expr_visitor::visit_expression(expr);
+    return safe_pointer_cast<ConstraintTerm>(ans);
 }
 
 }  // namespace coek

--- a/lib/coek/coek/compact/visitor_exprtemplate.hpp
+++ b/lib/coek/coek/compact/visitor_exprtemplate.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../ast/constraint_terms.hpp"
+
+namespace coek {
+
+expr_pointer_t convert_expr_template(const expr_pointer_t& expr);
+
+std::shared_ptr<ConstraintTerm> convert_con_template(const std::shared_ptr<ConstraintTerm>& expr);
+
+}  // namespace coek

--- a/lib/coek/coek/model/compact_model.cpp
+++ b/lib/coek/coek/model/compact_model.cpp
@@ -71,13 +71,6 @@ VariableMap& CompactModel::add_variable(VariableMap& vars)
 {
     repn->variables.insert(repn->variables.end(), vars.begin(), vars.end());
     repn->variable_names.insert(repn->variable_names.end(), vars.size(), "");
-    /*
-    auto end = vars.end();
-    for (auto it=vars.begin(); it != end; ++it) {
-        repn->variables.push_back(*it);
-        repn->variable_names.push_back("");
-        }
-    */
     return vars;
 }
 
@@ -85,13 +78,6 @@ VariableMap& CompactModel::add_variable(VariableMap&& vars)
 {
     repn->variables.insert(repn->variables.end(), vars.begin(), vars.end());
     repn->variable_names.insert(repn->variable_names.end(), vars.size(), "");
-    /*
-    auto end = vars.end();
-    for (auto it=vars.begin(); it != end; ++it) {
-        repn->variables.push_back(*it);
-        repn->variable_names.push_back("");
-        }
-    */
     return vars;
 }
 
@@ -99,13 +85,6 @@ VariableArray& CompactModel::add_variable(VariableArray& vars)
 {
     repn->variables.insert(repn->variables.end(), vars.begin(), vars.end());
     repn->variable_names.insert(repn->variable_names.end(), vars.size(), "");
-    /*
-    auto end = vars.end();
-    for (auto it=vars.begin(); it != end; ++it) {
-        repn->variables.push_back(*it);
-        repn->variable_names.push_back("");
-        }
-    */
     return vars;
 }
 
@@ -113,13 +92,6 @@ VariableArray& CompactModel::add_variable(VariableArray&& vars)
 {
     repn->variables.insert(repn->variables.end(), vars.begin(), vars.end());
     repn->variable_names.insert(repn->variable_names.end(), vars.size(), "");
-    /*
-    auto end = vars.end();
-    for (auto it=vars.begin(); it != end; ++it) {
-        repn->variables.push_back(*it);
-        repn->variable_names.push_back("");
-        }
-    */
     return vars;
 }
 

--- a/lib/coek/coek/model/writer_lp.cpp
+++ b/lib/coek/coek/model/writer_lp.cpp
@@ -63,17 +63,7 @@ void print_repn(std::ostream& ostr, const QuadraticExpr& repn,
         std::map<size_t, double> vval;
         size_t i = 0;
         for (auto& it : repn.linear_vars) {
-#if 0
-            size_t index = get_vid_value(vid, it->index);
-
-            auto curr = vval.find(index);
-            if (curr != vval.end())
-                vval[index] += repn.linear_coefs[i];
-            else
-                vval[index] = repn.linear_coefs[i];
-#else
             vval[get_vid_value(vid, it->index)] += repn.linear_coefs[i];
-#endif
             i++;
         }
 
@@ -92,24 +82,10 @@ void print_repn(std::ostream& ostr, const QuadraticExpr& repn,
             size_t lindex = get_vid_value(vid, repn.quadratic_lvars[ii]->index);
             size_t rindex = get_vid_value(vid, repn.quadratic_rvars[ii]->index);
 
-#if 0
-            std::pair<int, int> tmp;
-            if (lindex < rindex)
-                tmp = std::pair<size_t, size_t>(lindex, rindex);
-            else
-                tmp = std::pair<size_t, size_t>(rindex, lindex);
-
-            auto curr = qval.find(tmp);
-            if (curr != qval.end())
-                qval[tmp] += repn.quadratic_coefs[ii];
-            else
-                qval[tmp] = repn.quadratic_coefs[ii];
-#else
             if (lindex < rindex)
                 qval[{lindex, rindex}] += repn.quadratic_coefs[ii];
             else
                 qval[{rindex, lindex}] += repn.quadratic_coefs[ii];
-#endif
         }
 
         ostr << "+ [\n";
@@ -145,16 +121,7 @@ void print_repn(fmt::ostream& ostr, const QuadraticExpr& repn,
         std::map<size_t, double> vval;
         size_t i = 0;
         for (auto& it : repn.linear_vars) {
-#    if 0
-            size_t index = get_vid_value(vid, it->index);
-
-            if (auto curr{ vval.find(index) };  curr != vval.end() )
-                curr->second += repn.linear_coefs[i];
-            else
-                vval[index] = repn.linear_coefs[i];
-#    else
             vval[get_vid_value(vid, it->index)] += repn.linear_coefs[i];
-#    endif
             i++;
         }
 
@@ -170,24 +137,10 @@ void print_repn(fmt::ostream& ostr, const QuadraticExpr& repn,
             size_t lindex = get_vid_value(vid, repn.quadratic_lvars[ii]->index);
             size_t rindex = get_vid_value(vid, repn.quadratic_rvars[ii]->index);
 
-#    if 0
-            std::pair<int, int> tmp;
-            if (lindex < rindex)
-                tmp = std::pair<size_t, size_t>(lindex, rindex);
-            else
-                tmp = std::pair<size_t, size_t>(rindex, lindex);
-
-            auto curr = qval.find(tmp);
-            if (curr != qval.end())
-                curr->second += repn.quadratic_coefs[ii];
-            else
-                qval[tmp] = repn.quadratic_coefs[ii];
-#    else
             if (lindex < rindex)
                 qval[{lindex, rindex}] += repn.quadratic_coefs[ii];
             else
                 qval[{rindex, lindex}] += repn.quadratic_coefs[ii];
-#    endif
         }
 
         ostr.print("+ [\n");

--- a/lib/coek/coek/util/tictoc.cpp
+++ b/lib/coek/coek/util/tictoc.cpp
@@ -23,7 +23,7 @@ void TicTocTimer::tic(const std::string& msg)
 double TicTocTimer::toc(const std::string& msg)
 {
     auto t_end = std::chrono::high_resolution_clock::now();
-    auto sec = (t_end - t_start).count() * 1E-9;
+    auto sec = static_cast<double>((t_end - t_start).count()) * 1E-9;
     std::cout << "[";
     std::cout.width(10);
     std::cout << std::fixed << std::setprecision(2) << sec << "] " << msg << std::endl;

--- a/lib/coek/examples/simplelp1_solve.cpp
+++ b/lib/coek/examples/simplelp1_solve.cpp
@@ -17,6 +17,7 @@ void simplelp1_solve()
     coek::Solver solver("gurobi");
     auto status = solver.solve(m);
 
+    std::cout << "Solve Status:" << status << std::endl;
     std::cout << "Value of " + x.name() + ": " << x.value() << std::endl;
     std::cout << "Value of " + y.name() + ": " << y.value() << std::endl;
 }

--- a/lib/coek/test/test_indexed.cpp
+++ b/lib/coek/test/test_indexed.cpp
@@ -889,7 +889,8 @@ TEST_CASE("expr_expand", "[smoke]")
                 repn.collect_terms(E);
 
                 static std::list<std::string> constval = {std::to_string(0.0)};
-                static std::list<std::string> nonlinear = {"[", "/", std::to_string(1.0), "w", "]"};
+                static std::list<std::string> nonlinear
+                    = {"[", "If", "p", "w", "[", "/", std::to_string(1.0), "w", "]", "]"};
                 REQUIRE(repn.constval->to_list() == constval);
                 REQUIRE(repn.linear_coefs.size() == 0);
                 REQUIRE(repn.quadratic_coefs.size() == 0);
@@ -908,7 +909,25 @@ TEST_CASE("expr_expand", "[smoke]")
                 repn.collect_terms(E);
 
                 static std::list<std::string> constval = {std::to_string(0.0)};
-                static std::list<std::string> nonlinear = {"[", "/", std::to_string(1.0), "w", "]"};
+                static std::list<std::string> nonlinear = {"[",
+                                                           "If",
+                                                           "[",
+                                                           "<",
+                                                           "-Inf",
+                                                           "[",
+                                                           "+",
+                                                           "p",
+                                                           std::to_string(1.0),
+                                                           "]",
+                                                           std::to_string(0.0),
+                                                           "]",
+                                                           "w",
+                                                           "[",
+                                                           "/",
+                                                           std::to_string(1.0),
+                                                           "w",
+                                                           "]",
+                                                           "]"};
                 REQUIRE(repn.constval->to_list() == constval);
                 REQUIRE(repn.linear_coefs.size() == 0);
                 REQUIRE(repn.quadratic_coefs.size() == 0);
@@ -917,7 +936,7 @@ TEST_CASE("expr_expand", "[smoke]")
         }
     }
 
-    SECTION("constriaints")
+    SECTION("constraints")
     {
         WHEN("inequality")
         {

--- a/test/aml_comparisons/coek/models/coek_models.hpp
+++ b/test/aml_comparisons/coek/models/coek_models.hpp
@@ -63,7 +63,7 @@ inline void check_data(const std::string& name, const std::vector<size_t>& data,
                                  + " but only have " + std::to_string(data.size()));
 }
 
-inline void create_instance(coek::Model& model, const std::string& name,
+inline bool create_instance(coek::Model& model, const std::string& name,
                             const std::vector<size_t>& data)
 {
     if (false) {
@@ -76,16 +76,19 @@ inline void create_instance(coek::Model& model, const std::string& name,
     else if (name == "fac-array") {
         check_data(name, data, 1);
         fac_array(model, data[0]);
+        return true;
     }
 #endif
     else if (name == "fac-scalar") {
         check_data(name, data, 1);
         fac_scalar(model, data[0]);
+        return true;
     }
 #if __cpp_lib_variant
     else if (name == "lqcp-array") {
         check_data(name, data, 1);
         lqcp_array(model, data[0]);
+        return true;
     }
 #    ifdef COEK_WITH_COMPACT_MODEL
     else if (name == "lqcp-compact") {
@@ -93,16 +96,19 @@ inline void create_instance(coek::Model& model, const std::string& name,
         coek::CompactModel cmodel;
         lqcp_compact(cmodel, data[0]);
         model = cmodel.expand();
+        return true;
     }
     else if (name == "lqcp-map") {
         check_data(name, data, 1);
         lqcp_map(model, data[0]);
+        return true;
     }
 #    endif
 #endif
     else if (name == "lqcp-scalar") {
         check_data(name, data, 1);
         lqcp_scalar(model, data[0]);
+        return true;
     }
     //
     // misc
@@ -111,32 +117,58 @@ inline void create_instance(coek::Model& model, const std::string& name,
     else if (name == "knapsack-array") {
         check_data(name, data, 1);
         knapsack_array(model, data[0]);
+        return true;
     }
 #endif
     else if (name == "knapsack-scalar") {
         check_data(name, data, 1);
         knapsack_scalar(model, data[0]);
+        return true;
     }
 #if __cpp_lib_variant
     else if (name == "nqueens-array") {
         check_data(name, data, 1);
         nqueens_array(model, data[0]);
+        return true;
     }
 #endif
     else if (name == "nqueens-scalar") {
         check_data(name, data, 1);
         nqueens_scalar(model, data[0]);
+        return true;
     }
 #if __cpp_lib_variant
     else if (name == "pmedian-array") {
         check_data(name, data, 2);
         pmedian_array(model, data[0], data[1]);
+        return true;
     }
 #endif
     else if (name == "pmedian-scalar") {
         check_data(name, data, 2);
         pmedian_scalar(model, data[0], data[1]);
+        return true;
     }
-    else
-        throw std::runtime_error("Unknown test model: " + name);
+
+    return false;
 }
+
+#ifdef COEK_WITH_COMPACT_MODEL
+inline bool create_instance(coek::CompactModel& model, const std::string& name,
+                            const std::vector<size_t>& data)
+{
+    if (false) {
+    }
+
+    //
+    // jump
+    //
+    else if (name == "lqcp-compact") {
+        check_data(name, data, 1);
+        lqcp_compact(model, data[0]);
+        return true;
+    }
+
+    return false;
+}
+#endif

--- a/test/aml_comparisons/coek/writer.cpp
+++ b/test/aml_comparisons/coek/writer.cpp
@@ -55,15 +55,34 @@ int main(int argc, char* argv[])
     if (debug)
         std::cout << "Filename: " << filename << " Model: " << model_name << " Data: " << data[0]
                   << std::endl;
+    bool constructed = false;
     coek::Model model;
     try {
-        create_instance(model, model_name, data);
+        constructed = create_instance(model, model_name, data);
     }
     catch (std::exception& e) {
         std::cout << "ERROR - " << e.what() << std::endl;
         return 1;
     }
-    model.write(filename);
+    if (constructed) {
+        model.write(filename);
+        return 0;
+    }
 
-    return 0;
+#ifdef COEK_WITH_COMPACT_MODEL
+    coek::CompactModel cmodel;
+    try {
+        constructed = create_instance(cmodel, model_name, data);
+    }
+    catch (std::exception& e) {
+        std::cout << "ERROR - " << e.what() << std::endl;
+        return 1;
+    }
+    if (constructed) {
+        cmodel.write(filename);
+        return 0;
+    }
+#endif
+
+    return 1;
 }


### PR DESCRIPTION
1. Reworked visitor for expanding compact expressions.

This code hadn't been revisited during the recent rework of visitors.

2. Misc changes to eliminate build warnings.

3. Misc changes to simplify for loops.

4. Simplification of LP writer.

Leveraging the fact that std::map<TYPE,int> values are initialized to 0.

5. Draft setup of AML tests with compact models.