### PR TITLE
Updates to build without local TPLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ option(with_openmp "Compiled with openmp enabled" ON)
 option(with_tests "Build tests" OFF)
 option(with_apps "Build apps" ON)
 option(with_docs "Build documentation" OFF)
-option(with_python "Build/Install Python libs" ${Python_FOUND})
+option(with_python "Build/Install Python libs" OFF)
 
 ##################### Checks for compiler #####################
 

--- a/app/demos/demo1.cpp
+++ b/app/demos/demo1.cpp
@@ -24,7 +24,6 @@ coek::Model knapsack(size_t N)
     
     auto model = coek::Model();
 
-#if __cpp_lib_variant
     auto x = coek::variable(N).bounds(0, 1).value(0);
     model.add(x);
     
@@ -37,7 +36,6 @@ coek::Model knapsack(size_t N)
     auto con = coek::expression();
     for (size_t n : coek::range(N)) con += w[n] * x(n);
     model.add(con <= W);
-#endif
 
     return model;
 }
@@ -58,7 +56,7 @@ int main(int argc, char* argv[])
     if (solver_name == "gurobi") {
         coek::Solver solver;
         solver.initialize(solver_name);
-        //solver.set_option("OutputFlag", debug);
+        solver.set_option("OutputFlag", 1);
         //solver.set_option("TimeLimit", 0.0);
 
         auto res = solver.solve(model);

--- a/app/demos/demo1.cpp
+++ b/app/demos/demo1.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
     if (solver_name == "gurobi") {
         coek::Solver solver;
         solver.initialize(solver_name);
-        solver.set_option("OutputFlag", 1);
+        //solver.set_option("OutputFlag", 1);
         //solver.set_option("TimeLimit", 0.0);
 
         auto res = solver.solve(model);

--- a/cmake/FindCppAD.cmake
+++ b/cmake/FindCppAD.cmake
@@ -1,0 +1,109 @@
+# ----------------------------------------------------------------------------
+#  CppADCodeGen: C++ Algorithmic Differentiation with Source Code Generation:
+#    Copyright (C) 2012 Ciengis
+#    Copyright (C) 2020 Joao Leal
+#
+#  CppADCodeGen is distributed under multiple licenses:
+#
+#   - Eclipse Public License Version 1.0 (EPL1), and
+#   - GNU General Public License Version 3 (GPL3).
+#
+#  EPL1 terms and conditions can be found in the file "epl-v10.txt", while
+#  terms and conditions for the GPL3 can be found in the file "gpl3.txt".
+# ----------------------------------------------------------------------------
+#
+# - Try to find CppAD
+# Once done this will define
+#  CPPAD_FOUND - System has CppAD
+#  CPPAD_INCLUDE_DIRS - The CppAD include directories
+#  CPPAD_LIBRARY_DIRS - The library directories needed to use CppAD
+#  CPPAD_LIBRARIES    - The libraries needed to use CppAD
+
+IF (CPPAD_INCLUDES AND CPPAD_LIBRARIES)
+    SET(CPPAD_FIND_QUIETLY TRUE)
+ENDIF ()
+
+
+IF (DEFINED CPPAD_HOME)
+
+    FIND_PATH(CPPAD_INCLUDE_DIR NAMES cppad/cppad.hpp
+            PATHS "${CPPAD_HOME}"
+            NO_DEFAULT_PATH)
+
+    FIND_LIBRARY(CPPAD_LIBRARY
+            cppad_lib
+            PATHS "${CPPAD_HOME}/lib"
+            NO_DEFAULT_PATH)
+
+    SET(CPPAD_INCLUDE_DIRS ${CPPAD_INCLUDE_DIR})
+    SET(CPPAD_LIBRARIES ${CPPAD_LIBRARY})
+    SET(CPPAD_FOUND TRUE)
+
+ELSE ()
+
+    FIND_PACKAGE(PkgConfig)
+
+    IF (PKG_CONFIG_FOUND)
+        pkg_check_modules(CPPAD QUIET cppad)
+    ENDIF ()
+
+
+    IF (NOT CPPAD_FOUND)
+
+        FIND_PATH(CPPAD_INCLUDE_DIR NAMES cppad/cppad.hpp
+                HINTS "$ENV{CPPAD_HOME}"
+                PATH_SUFFIXES include)
+
+        FIND_LIBRARY(CPPAD_LIBRARY
+                cppad_lib
+                HINTS "$ENV{CPPAD_HOME}/lib"
+                PATH_SUFFIXES lib)
+
+        IF (CPPAD_INCLUDE_DIR)
+            SET(CPPAD_INCLUDE_DIRS ${CPPAD_INCLUDE_DIR})
+        ENDIF ()
+
+        IF (CPPAD_LIBRARY)
+            SET(CPPAD_LIBRARIES ${CPPAD_LIBRARY})
+        ENDIF ()
+
+        INCLUDE(FindPackageHandleStandardArgs)
+        # handle the QUIETLY and REQUIRED arguments and set CPPAD_FOUND to TRUE
+        # if all listed variables are TRUE
+        find_package_handle_standard_args(CppAD DEFAULT_MSG
+                CPPAD_INCLUDE_DIRS)
+
+        MARK_AS_ADVANCED(CPPAD_INCLUDE_DIRS CPPAD_LIBRARIES)
+
+    ENDIF ()
+ENDIF ()
+
+IF (CPPAD_FOUND)
+
+    IF (CppAD_FIND_VERSION)
+
+        IF (NOT CPPAD_VERSION)
+            FILE(STRINGS ${CPPAD_INCLUDE_DIR}/cppad/configure.hpp CPPAD_VERSION_LINE
+                    REGEX "CPPAD_PACKAGE_STRING +\"cppad-[0-9]+(\\.[0-9]+)?\"")
+            STRING(REGEX MATCH "[0-9]+(\\.[0-9]+)?" CPPAD_VERSION "${CPPAD_VERSION_LINE}")
+        ENDIF ()
+
+        IF (CppAD_FIND_VERSION_EXACT)
+            IF (NOT "${CPPAD_VERSION}" VERSION_EQUAL "${CppAD_FIND_VERSION}")
+                SET(CPPAD_FOUND FALSE)
+                MESSAGE(FATAL_ERROR "Found CppAD version '${CPPAD_VERSION}' but version '${CppAD_FIND_VERSION}' is required")
+            ENDIF ()
+        ELSE ()
+            IF ("${CPPAD_VERSION}" VERSION_LESS "${CppAD_FIND_VERSION}")
+                SET(CPPAD_FOUND FALSE)
+                MESSAGE(FATAL_ERROR "Found CppAD version '${CPPAD_VERSION}' but at least version '${CppAD_FIND_VERSION}' is required")
+            ENDIF ()
+        ENDIF ()
+
+    ENDIF ()
+
+    IF (CPPAD_FOUND AND NOT CPPAD_FIND_QUIETLY)
+        MESSAGE(STATUS "package CppAD ${CPPAD_VERSION} found")
+    ENDIF ()
+
+ENDIF ()

--- a/lib/coek/coek/CMakeLists.txt
+++ b/lib/coek/coek/CMakeLists.txt
@@ -80,7 +80,7 @@ if(with_fmtlib)
     find_package(fmt REQUIRED)
     list(APPEND coek_compile_options -DWITH_FMTLIB -Wextra -Wconversion -Wpedantic -Wsign-conversion)
     list(APPEND coek_link_libraries fmt::fmt)
-    list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include)
+    #list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include)
 endif()
 
 # Caliper LIBRARY
@@ -94,7 +94,7 @@ endif()
 if(with_rapidjson)
     find_package(RapidJSON REQUIRED)
     list(APPEND coek_compile_options -DWITH_RAPIDJSON)
-    list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include)
+    #list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include)
 endif()
 
 # gcov
@@ -119,19 +119,21 @@ endif()
 
 # CppAD LIBRARY
 if(with_cppad)
+    find_package(CppAD REQUIRED)
     list(APPEND sources
                 autograd/cppad_repn.cpp)
     list(APPEND coek_compile_options "-DWITH_CPPAD")
-    list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include)
+    #list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include)
 endif()
 
 # ASL LIBRARY
 if(with_asl)
+    find_package(ampl-asl REQUIRED)
     list(APPEND sources
                 autograd/asl_repn.cpp)
     list(APPEND coek_compile_options "-DWITH_ASL")
-    list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include/asl)
-    list(APPEND coek_link_directories ${CMAKE_INSTALL_PREFIX}/lib)
+    #list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include/asl)
+    #list(APPEND coek_link_directories ${CMAKE_INSTALL_PREFIX}/lib)
     if (${with_openmp})
         list(APPEND coek_link_libraries asl-mt)
         list(APPEND coek_link_libraries OpenMP::OpenMP_CXX)

--- a/lib/coek/coek/CMakeLists.txt
+++ b/lib/coek/coek/CMakeLists.txt
@@ -123,6 +123,7 @@ if(with_cppad)
     list(APPEND sources
                 autograd/cppad_repn.cpp)
     list(APPEND coek_compile_options "-DWITH_CPPAD")
+    list(APPEND coek_link_libraries ${CPPAD_LIBRARIES})
     #list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include)
 endif()
 
@@ -135,11 +136,12 @@ if(with_asl)
     #list(APPEND coek_include_directories ${CMAKE_INSTALL_PREFIX}/include/asl)
     #list(APPEND coek_link_directories ${CMAKE_INSTALL_PREFIX}/lib)
     if (${with_openmp})
-        list(APPEND coek_link_libraries asl-mt)
+        get_property(asllib TARGET asl-mt PROPERTY IMPORTED_LOCATION_RELEASE)
         list(APPEND coek_link_libraries OpenMP::OpenMP_CXX)
     else()
-        list(APPEND coek_link_libraries asl)
+        get_property(asllib TARGET asl PROPERTY IMPORTED_LOCATION_RELEASE)
     endif()
+    list(APPEND coek_link_libraries ${asllib})
 endif()
 
 #

--- a/lib/coek/coek/autograd/asl_repn.cpp
+++ b/lib/coek/coek/autograd/asl_repn.cpp
@@ -8,9 +8,9 @@
 #include "coek/ast/value_terms.hpp"
 
 // AMPL includes
-#include "asl.h"
-#include "asl_pfgh.h"
-#include "getstub.h"
+#include "asl/asl.h"
+#include "asl/asl_pfgh.h"
+#include "asl/getstub.h"
 #ifdef range
 #    undef range
 #endif

--- a/lib/coek/doc/CMakeLists.txt
+++ b/lib/coek/doc/CMakeLists.txt
@@ -99,7 +99,8 @@ endif()
 add_custom_target(coek_html DEPENDS ${SPHINX_INDEX_FILE})
 add_custom_target(coek_pdf DEPENDS ${LATEX_BUILD}/coek.pdf)
 
-add_custom_target(doc_coek DEPENDS coek_doxygen coek_html coek_pdf)
+#add_custom_target(doc_coek DEPENDS coek_doxygen coek_html coek_pdf)
+add_custom_target(doc_coek DEPENDS coek_doxygen coek_html)
 
 # Add an install target to install the docs
 include(GNUInstallDirs)

--- a/tpl/thirdparty.cmake
+++ b/tpl/thirdparty.cmake
@@ -15,9 +15,9 @@ add_revision(catch2
   )
 
 add_revision(cppad
-  SRC CppAD-20220000.5
-  URL "https://github.com/coin-or/CppAD/archive/refs/tags/20220000.5.tar.gz"
-  URL_HASH SHA256=9fb4562f6169855eadcd86ac4671593d1c0edf97bb6ce7cbb28e19af2bfc165e
+  SRC CppAD-20240000.4
+  URL "https://github.com/coin-or/CppAD/archive/refs/tags/20240000.4.tar.gz"
+  URL_HASH SHA256=0dfc1e30b32d5dd3086ee3adb6d2746a019e9d670b644c4d5ec1df3c35dd1fe5
   )
 
 add_revision(fmtlib


### PR DESCRIPTION
Local TPLs still work, but are now not necessary.

The find_packages() CMake logic now works for all external dependencies.