### PR TITLE
Several changes

### DIFF
--- a/lib/coek/coek/api/constraint.cpp
+++ b/lib/coek/coek/api/constraint.cpp
@@ -29,6 +29,12 @@ Constraint& Constraint::operator=(const Constraint& expr)
     return *this;
 }
 
+bool Constraint::active() const { return repn->active; }
+
+void Constraint::activate() { repn->active = true; }
+
+void Constraint::deactivate() { repn->active = false; }
+
 size_t Constraint::id() const { return repn->index; }
 
 bool Constraint::is_inequality() const { return repn->is_inequality(); }

--- a/lib/coek/coek/api/constraint.hpp
+++ b/lib/coek/coek/api/constraint.hpp
@@ -59,6 +59,13 @@ class Constraint {
 
     Constraint expand();
 
+    /** \returns the active state */
+    bool active() const;
+    /** Sets the active state to true */
+    void activate();
+    /** Sets the active state to false */
+    void deactivate();
+
     /** \returns the unique integer constraint ID */
     size_t id() const;
 

--- a/lib/coek/coek/api/objective.cpp
+++ b/lib/coek/coek/api/objective.cpp
@@ -19,6 +19,12 @@ Objective& Objective::operator=(const Objective& expr)
     return *this;
 }
 
+bool Objective::active() const { return repn->active; }
+
+void Objective::activate() { repn->active = true; }
+
+void Objective::deactivate() { repn->active = false; }
+
 size_t Objective::id() const { return repn->index; }
 
 double Objective::value() const { return repn->eval(); }

--- a/lib/coek/coek/api/objective.hpp
+++ b/lib/coek/coek/api/objective.hpp
@@ -44,6 +44,13 @@ class Objective {
     /** \returns the objective name */
     std::string name() const;
 
+    /** \returns the active state */
+    bool active() const;
+    /** Sets the active state to true */
+    void activate();
+    /** Sets the active state to false */
+    void deactivate();
+
     /** \returns the unique integer objective ID */
     size_t id() const;
 

--- a/lib/coek/coek/ast/constraint_terms.cpp
+++ b/lib/coek/coek/ast/constraint_terms.cpp
@@ -19,14 +19,15 @@ std::mutex ConstraintTerm_mtx;
 //
 size_t ObjectiveTerm::count = 0;
 
-ObjectiveTerm::ObjectiveTerm() : body(ZeroConstant), sense(true)
+ObjectiveTerm::ObjectiveTerm() : body(ZeroConstant), sense(true), active(true)
 {
     ObjectiveTerm_mtx.lock();
     index = count++;
     ObjectiveTerm_mtx.unlock();
 }
 
-ObjectiveTerm::ObjectiveTerm(const expr_pointer_t& _body, bool _sense) : body(_body), sense(_sense)
+ObjectiveTerm::ObjectiveTerm(const expr_pointer_t& _body, bool _sense)
+    : body(_body), sense(_sense), active(true)
 {
     ObjectiveTerm_mtx.lock();
     index = count++;
@@ -48,7 +49,7 @@ ConstraintTerm::ConstraintTerm()
 
 ConstraintTerm::ConstraintTerm(const expr_pointer_t& _lower, const expr_pointer_t& _body,
                                const expr_pointer_t& _upper)
-    : lower(_lower), body(_body), upper(_upper)
+    : active(true), lower(_lower), body(_body), upper(_upper)
 {
     ConstraintTerm_mtx.lock();
     index = count++;
@@ -57,7 +58,7 @@ ConstraintTerm::ConstraintTerm(const expr_pointer_t& _lower, const expr_pointer_
 
 ConstraintTerm::ConstraintTerm(const expr_pointer_t& _lower, const expr_pointer_t& _body,
                                int /*_upper*/)
-    : lower(_lower), body(_body)
+    : active(true), lower(_lower), body(_body)
 {
     ConstraintTerm_mtx.lock();
     index = count++;
@@ -66,7 +67,7 @@ ConstraintTerm::ConstraintTerm(const expr_pointer_t& _lower, const expr_pointer_
 
 ConstraintTerm::ConstraintTerm(int /*_lower*/, const expr_pointer_t& _body,
                                const expr_pointer_t& _upper)
-    : body(_body), upper(_upper)
+    : active(true), body(_body), upper(_upper)
 {
     ConstraintTerm_mtx.lock();
     index = count++;
@@ -77,7 +78,7 @@ ConstraintTerm::ConstraintTerm(int /*_lower*/, const expr_pointer_t& _body,
 // EmptyConstraintTerm
 //
 
-EmptyConstraintTerm::EmptyConstraintTerm() : ConstraintTerm() {}
+EmptyConstraintTerm::EmptyConstraintTerm() : ConstraintTerm() { active = false; }
 
 std::shared_ptr<EmptyConstraintTerm> EmptyConstraintRepn = std::make_shared<EmptyConstraintTerm>();
 

--- a/lib/coek/coek/ast/constraint_terms.hpp
+++ b/lib/coek/coek/ast/constraint_terms.hpp
@@ -16,6 +16,7 @@ class ObjectiveTerm : public BaseExpressionTerm {
    public:
     expr_pointer_t body;
     bool sense;
+    bool active;
     size_t index;
     std::string name;
 
@@ -46,6 +47,7 @@ class ConstraintTerm : public BaseExpressionTerm {
     static size_t count;
 
    public:
+    bool active;
     size_t index;
     expr_pointer_t lower;
     expr_pointer_t body;

--- a/lib/coek/coek/model/model.cpp
+++ b/lib/coek/coek/model/model.cpp
@@ -31,23 +31,27 @@ std::ostream& operator<<(std::ostream& ostr, const Model& arg)
 }
 
 // GCOVR_EXCL_START
-void Model::print_equations() const { print_equations(std::cout); }
+void Model::print_equations(bool active) const { print_equations(std::cout, active); }
 
 void Model::print_values() { print_values(std::cout); }
 // GCOVR_EXCL_STOP
 
-void Model::print_equations(std::ostream& ostr) const
+void Model::print_equations(std::ostream& ostr, bool active) const
 {
     ostr << "MODEL" << std::endl;
     size_t ctr = 0;
     ostr << "  Objectives" << std::endl;
-    for (auto it = repn->objectives.begin(); it != repn->objectives.end(); ++it) {
-        ostr << "    " << ctr++ << ":  " << *it << std::endl;
+    for (auto& obj : repn->objectives) {
+        if (not active or obj.active())
+            ostr << "    " << ctr << ":  " << obj << std::endl;
+        ctr++;
     }
     ctr = 0;
     ostr << "  Constraints" << std::endl;
-    for (auto it = repn->constraints.begin(); it != repn->constraints.end(); ++it) {
-        ostr << "    " << ctr++ << ":  " << *it << std::endl;
+    for (auto& con : repn->constraints) {
+        if (not active or con.active())
+            ostr << "    " << ctr << ":  " << con << std::endl;
+        ctr++;
     }
 }
 

--- a/lib/coek/coek/model/model.hpp
+++ b/lib/coek/coek/model/model.hpp
@@ -276,9 +276,9 @@ class Model {
     void write(const std::string& filename, std::map<size_t, size_t>& varmap,
                std::map<size_t, size_t>& conmap);
     /** Print the equations in the model to \c std::cout */
-    void print_equations() const;
+    void print_equations(bool active = true) const;
     /** Print the equations in the model to the specified output stream */
-    void print_equations(std::ostream& ostr) const;
+    void print_equations(std::ostream& ostr, bool active = true) const;
     /** Print the values in the model to \c std::cout */
     void print_values();
     /** Print the values in the model to the specified output stream */

--- a/lib/coek/coek/solvers/highs/coek_highs.hpp
+++ b/lib/coek/coek/solvers/highs/coek_highs.hpp
@@ -28,7 +28,7 @@ class HighsSolver : public SolverRepn {
 
    protected:
     void collect_results(Model& model, std::shared_ptr<SolverResults>& results);
-    void pre_solve();
+    void pre_solve(Model& coek_model);
     void post_solve();
 };
 

--- a/lib/coek/test/smoke/test_writers.cpp
+++ b/lib/coek/test/smoke/test_writers.cpp
@@ -698,6 +698,7 @@ TEST_CASE("model_writer", "[smoke]")
             REQUIRE(run_test(model, "testing6", suffix));
     }
 
+#ifdef WITH_CPPAD
     // TODO - Add separate NLP writer tests to confirm the variable mappings
     SECTION("testing1-nlp")
     {
@@ -706,6 +707,7 @@ TEST_CASE("model_writer", "[smoke]")
         for (const std::string& suffix : linear)
             REQUIRE(run_test(nlp, "testing1", suffix));
     }
+#endif
 }
 
 #if 0
@@ -812,6 +814,7 @@ TEST_CASE("model_io", "[smoke]")
 ");
         }
 
+#ifdef WITH_CPPAD
         WHEN("nlp - cppad")
         {
             coek::NLPModel nlp(model, "cppad");
@@ -837,6 +840,7 @@ MODEL\n\
     2:  0 <= 3*b + q <= 1\n\
     3:  2 < 3*b + q < 3\n\n");
         }
+#endif
     }
 
     SECTION("Model values")
@@ -861,6 +865,7 @@ MODEL\n\
    1:  b 0.5 0 1 0\n");
         }
 
+#ifdef WITH_CPPAD
         WHEN("nlp - cppad")
         {
             coek::NLPModel nlp(model, "cppad");
@@ -872,5 +877,6 @@ MODEL\n\
    0: a 0 0 1 0\n\
    1: b 0.5 0 1 0\n");
         }
+#endif
     }
 }

--- a/lib/coek/test/solver/TestModels.cpp
+++ b/lib/coek/test/solver/TestModels.cpp
@@ -120,7 +120,7 @@ class SimpleQP2 : public TestModel {
     SimpleQP2()
     {
         primal_solution = {375, 250};
-        optimal_objective = 2875000;
+        optimal_objective = 2781250;
 
         // Model
         model.name("simpleqp2");
@@ -128,11 +128,53 @@ class SimpleQP2 : public TestModel {
         auto x = m.add(coek::variable("x").bounds(0, m.inf));
         auto y = m.add(coek::variable("y").bounds(0, m.inf));
 
-        m.add_objective(10 * x * x + 5 * x * y + 4 * y * x + 10 * y * y);
+        m.add_objective(10 * x * x + 5 * x * y + 3 * y * x + 10 * y * y);
         m.add_constraint(2 * x + 3 * y >= 1500);
         m.add_constraint(2 * x + y >= 1000);
     }
     virtual ~SimpleQP2() {}
+};
+
+class SimpleQP3 : public TestModel {
+   public:
+    SimpleQP3()
+    {
+        primal_solution = {375, 250, 1};
+        optimal_objective = 2781876;
+
+        // Model
+        model.name("simpleqp3");
+        auto& m = model;
+        auto x = m.add(coek::variable("x").bounds(0, m.inf));
+        auto y = m.add(coek::variable("y").bounds(0, m.inf));
+        auto z = m.add(coek::variable("z").bounds(1, m.inf));
+
+        m.add_objective(10 * x * x + 5 * x * y + 3 * y * x + x * z + y * z + 10 * y * y + z * z);
+        m.add_constraint(2 * x + 3 * y >= 1500);
+        m.add_constraint(2 * x + y >= 1000);
+    }
+    virtual ~SimpleQP3() {}
+};
+
+class SimpleQP4 : public TestModel {
+   public:
+    SimpleQP4()
+    {
+        primal_solution = {375, 250, 1};
+        optimal_objective = 2781251;
+
+        // Model
+        model.name("simpleqp4");
+        auto& m = model;
+        auto x = m.add(coek::variable("x").bounds(0, m.inf));
+        auto y = m.add(coek::variable("y").bounds(0, m.inf));
+        auto z = m.add(coek::variable("z").bounds(1, m.inf));
+
+        m.add_objective(10 * x * x + 5 * x * y + 3 * y * x + 10 * y * y + z);
+        m.add_constraint(2 * x + 3 * y >= 1500);
+        m.add_constraint(2 * x + y >= 1000);
+    }
+    virtual ~SimpleQP4() {}
 };
 
 class LP_bounds1 : public TestModel {
@@ -260,6 +302,10 @@ std::shared_ptr<TestModel> model(const std::string& name)
         return std::make_shared<SimpleQP1>();
     if (name == "simpleqp2")
         return std::make_shared<SimpleQP2>();
+    if (name == "simpleqp3")
+        return std::make_shared<SimpleQP3>();
+    if (name == "simpleqp4")
+        return std::make_shared<SimpleQP4>();
     if (name == "qp_bounds")
         return std::make_shared<QP_bounds>();
     if (name == "lp_bounds1")

--- a/lib/coek/test/solver/test_examples.cpp
+++ b/lib/coek/test/solver/test_examples.cpp
@@ -285,8 +285,10 @@ TEST_CASE("ipopt_examples", "[solvers][ipopt]")
                 check(m.get_variables(), invquad_soln_5);
             }
 
+#        ifdef WITH_CPPAD
             WHEN("invquad_solve") { invquad_array_solve(); }
             WHEN("invquad_resolve") { invquad_array_resolve(); }
+#        endif
         }
 #    endif
     }

--- a/lib/coek/test/solver/test_gurobi.cpp
+++ b/lib/coek/test/solver/test_gurobi.cpp
@@ -49,6 +49,22 @@ TEST_CASE("gurobi_checks", "[solvers][gurobi]")
             auto res = solver.solve(m);
             REQUIRE(test->check_results(m, res) == true);
         }
+        SECTION("simpleqp3")
+        {
+            auto test = test::model("simpleqp3");
+            auto m = test->model;
+            REQUIRE(m.name() == "simpleqp3");
+            auto res = solver.solve(m);
+            REQUIRE(test->check_results(m, res) == true);
+        }
+        SECTION("simpleqp4")
+        {
+            auto test = test::model("simpleqp4");
+            auto m = test->model;
+            REQUIRE(m.name() == "simpleqp4");
+            auto res = solver.solve(m);
+            REQUIRE(test->check_results(m, res) == true);
+        }
         SECTION("lp_bounds1")
         {
             auto test = test::model("lp_bounds1");

--- a/lib/coek/test/solver/test_highs.cpp
+++ b/lib/coek/test/solver/test_highs.cpp
@@ -48,6 +48,22 @@ TEST_CASE("highs_checks", "[solvers][highs]")
             auto res = solver.solve(m);
             REQUIRE(test->check_results(m, res) == true);
         }
+        SECTION("simpleqp3")
+        {
+            auto test = test::model("simpleqp3");
+            auto m = test->model;
+            REQUIRE(m.name() == "simpleqp3");
+            auto res = solver.solve(m);
+            REQUIRE(test->check_results(m, res) == true);
+        }
+        SECTION("simpleqp4")
+        {
+            auto test = test::model("simpleqp4");
+            auto m = test->model;
+            REQUIRE(m.name() == "simpleqp4");
+            auto res = solver.solve(m);
+            REQUIRE(test->check_results(m, res) == true);
+        }
         SECTION("lp_bounds1")
         {
             auto test = test::model("lp_bounds1");


### PR DESCRIPTION
1. Adding active() methods for objectives and constraints. These container objects can be activated and deactivated. Note that these container objects should *not* be shared between models (though Coek does not prohibit that currently).  However, their underlying expressions *can* be shared between models.

2. Preliminary use of active() in the gurobi and highs interfaces.

3. Fixes to the highs quadratic objective terms, which needed to be a lower-triangular matrix, not an upper triangular.

4. Adding test cases to check QP logic for gurobi and highs.