### PR TITLE
Various performance improvements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,22 +6,38 @@
 # This uses Spack to install third-party dependencies in the `_spack` directory.
 #
 with_python="OFF"
+python_exe=""
 spack_reinstall=0
 spack_dev=0
 clang=0
+debug="OFF"
 spack_home=`pwd`/_spack
+with_valgrind=""
 while [[ $# -gt 0 ]]; do
     case $1 in
         --help)
-                    echo "build.sh [--python] [--clang] [--spack-reinstall] [--spack-dev] [--spack-home <dir>] [--help]"
+                    echo "build.sh [--help] [--clang] [--debug] [--python] [--python-exe <file>] [--spack-dev] [--spack-home <dir>] [--spack-reinstall] [--valgrind]"
                     exit 
         ;;
         --python)
                     with_python="ON"
                     shift
         ;;
+        --python-exe)
+                    python_exe="-DPython_EXECUTABLE=$2"
+                    shift
+                    shift
+        ;;
         --clang)
                     clang=1
+                    shift
+        ;;
+        --debug)
+                    debug="ON"
+                    shift
+        ;;
+        --valgrind)
+                    with_valgrind="valgrind"
                     shift
         ;;
         --spack-reinstall)
@@ -87,7 +103,7 @@ else
     . ${SPACK_HOME}/share/spack/setup-env.sh
     spack env create coekenv
     spack env activate coekenv
-    spack add asl cppad fmt rapidjson catch2 highs
+    spack add asl cppad fmt rapidjson catch2 highs $with_valgrind
     spack install
     spack env deactivate
 fi
@@ -102,5 +118,5 @@ echo "Building Coek"
 echo ""
 mkdir _build
 cd _build
-cmake -DCMAKE_PREFIX_PATH=${SPACK_HOME}/var/spack/environments/coekenv/.spack-env/view -Dwith_python=${with_python} -Dwith_gurobi=$with_gurobi -Dwith_highs=ON -Dwith_cppad=ON -Dwith_fmtlib=ON -Dwith_rapidjson=ON -Dwith_catch2=ON -Dwith_tests=ON -Dwith_asl=ON -Dwith_openmp=OFF ..
+cmake -DCMAKE_PREFIX_PATH=${SPACK_HOME}/var/spack/environments/coekenv/.spack-env/view -Dwith_debug=${debug} -Dwith_python=${with_python} $python_exe -Dwith_gurobi=$with_gurobi -Dwith_highs=ON -Dwith_cppad=ON -Dwith_fmtlib=ON -Dwith_rapidjson=ON -Dwith_catch2=ON -Dwith_tests=ON -Dwith_asl=ON -Dwith_openmp=OFF ..
 make -j20

--- a/lib/coek/coek/api/parameter_assoc_array.cpp
+++ b/lib/coek/coek/api/parameter_assoc_array.cpp
@@ -36,8 +36,9 @@ void ParameterAssocArrayRepn::value(double value)
 {
     parameter_template.value(value);
     if (values.size() > 0) {
+        Expression e(value);
         for (auto& var : values)
-            var.value(value);
+            var.value(e);
     }
 }
 

--- a/lib/coek/coek/api/variable_assoc_array.cpp
+++ b/lib/coek/coek/api/variable_assoc_array.cpp
@@ -46,8 +46,9 @@ void VariableAssocArrayRepn::value(double value)
 {
     variable_template.value(value);
     if (values.size() > 0) {
+        coek::Expression e(value);
         for (auto& var : values)
-            var.value(value);
+            var.value(e);
     }
 }
 
@@ -64,8 +65,9 @@ void VariableAssocArrayRepn::lower(double value)
 {
     variable_template.lower(value);
     if (values.size() > 0) {
+        coek::Expression e(value);
         for (auto& var : values)
-            var.lower(value);
+            var.lower(e);
     }
 }
 
@@ -82,8 +84,9 @@ void VariableAssocArrayRepn::upper(double value)
 {
     variable_template.upper(value);
     if (values.size() > 0) {
+        coek::Expression e(value);
         for (auto& var : values)
-            var.upper(value);
+            var.upper(e);
     }
 }
 
@@ -100,8 +103,10 @@ void VariableAssocArrayRepn::bounds(double lb, double ub)
 {
     variable_template.bounds(lb, ub);
     if (values.size() > 0) {
+        coek::Expression lower(lb);
+        coek::Expression upper(ub);
         for (auto& var : values)
-            var.bounds(lb, ub);
+            var.bounds(lower,upper);
     }
 }
 
@@ -109,8 +114,9 @@ void VariableAssocArrayRepn::bounds(const Expression& lb, double ub)
 {
     variable_template.bounds(lb, ub);
     if (values.size() > 0) {
+        coek::Expression upper(ub);
         for (auto& var : values)
-            var.bounds(lb, ub);
+            var.bounds(lb,upper);
     }
 }
 
@@ -118,8 +124,9 @@ void VariableAssocArrayRepn::bounds(double lb, const Expression& ub)
 {
     variable_template.bounds(lb, ub);
     if (values.size() > 0) {
+        coek::Expression lower(lb);
         for (auto& var : values)
-            var.bounds(lb, ub);
+            var.bounds(lower,ub);
     }
 }
 

--- a/test/aml_comparisons/coek/models/jump/fac_array.cpp
+++ b/test/aml_comparisons/coek/models/jump/fac_array.cpp
@@ -8,20 +8,20 @@ void fac_array(coek::Model& model, size_t F)
     size_t G = F;
 
     // Create variables
-    auto d = model.add(coek::variable("d")).bounds(0, COEK_INFINITY).value(1.0);
+    auto d = model.add(coek::variable("d").bounds(0, COEK_INFINITY).value(1.0));
 
-    auto y = model.add(coek::variable("y", {F, 2})).bounds(0, 1).value(1.0);
+    auto y = model.add(coek::variable("y", {F, 2}).bounds(0, 1).value(1.0));
 
-    auto z = model.add(coek::variable("z", {G + 1, G + 1, F}))
+    auto z = model.add(coek::variable("z", {G + 1, G + 1, F})
                  .bounds(0, 1)
                  .value(1.0)
-                 .within(coek::VariableTypes::Boolean);
+                 .within(coek::VariableTypes::Boolean));
 
-    auto s = model.add(coek::variable("s", {G + 1, G + 1, F})).bounds(0, COEK_INFINITY).value(0);
+    auto s = model.add(coek::variable("s", {G + 1, G + 1, F}).bounds(0, COEK_INFINITY).value(0));
 
-    auto r = model.add(coek::variable("r", {G + 1, G + 1, F, 2}))
+    auto r = model.add(coek::variable("r", {G + 1, G + 1, F, 2})
                  .bounds(-COEK_INFINITY, COEK_INFINITY)
-                 .value(0);
+                 .value(0));
 
     // Add objective
 

--- a/test/aml_comparisons/coek/models/jump/lqcp_array.cpp
+++ b/test/aml_comparisons/coek/models/jump/lqcp_array.cpp
@@ -20,8 +20,8 @@ void lqcp_array(coek::Model& model, size_t n)
     // double h2 = dx*dx;
     double a = 0.001;
 
-    auto y = model.add(coek::variable("y", {m + 1, n + 1})).bounds(0, 1).value(0);
-    auto u = model.add(coek::variable("u", m + 1)).bounds(-1, 1).value(0);
+    auto y = model.add(coek::variable("y", {m + 1, n + 1}).bounds(0, 1).value(0));
+    auto u = model.add(coek::variable("u", m + 1).bounds(-1, 1).value(0));
 
     // OBJECTIVE
     // First term

--- a/test/aml_comparisons/coek/models/jump/lqcp_map.cpp
+++ b/test/aml_comparisons/coek/models/jump/lqcp_map.cpp
@@ -24,8 +24,8 @@ void lqcp_map(coek::Model& model, size_t n)
 
     auto M = coek::RangeSet(0, m);
     auto N = coek::RangeSet(0, n);
-    auto y = model.add(coek::variable("y", M * N)).bounds(0, 1).value(0);
-    auto u = model.add(coek::variable("u", coek::RangeSet(1, m))).bounds(-1, 1).value(0);
+    auto y = model.add(coek::variable("y", M * N).bounds(0, 1).value(0));
+    auto u = model.add(coek::variable("u", coek::RangeSet(1, m)).bounds(-1, 1).value(0));
 
     // OBJECTIVE
     // First term

--- a/test/aml_comparisons/coek/models/misc/pmedian_array.cpp
+++ b/test/aml_comparisons/coek/models/misc/pmedian_array.cpp
@@ -13,9 +13,9 @@ void pmedian_array(coek::Model& model, size_t N, size_t P)
             d[n][m] = 1.0 + 1.0 / (n + m + 1);
     }
 
-    auto x = model.add(coek::variable("x", {N, M})).bounds(0, 1).value(0);
+    auto x = model.add(coek::variable("x", {N, M}).bounds(0, 1).value(0));
 
-    auto y = model.add(coek::variable("y", N)).bounds(0, 1).value(0);
+    auto y = model.add(coek::variable("y", N).bounds(0, 1).value(0));
 
     // obj
     auto obj = coek::expression();


### PR DESCRIPTION
The canonical use of add() for variables is changed to improve performance.

Using temporary expressions when initializing parameter/variable values and bounds.